### PR TITLE
feat[#8]: 스웨거 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/Toou/Toou/ToouApplication.java
+++ b/src/main/java/com/Toou/Toou/ToouApplication.java
@@ -1,9 +1,12 @@
 package com.Toou.Toou;
 
+import com.Toou.Toou.config.ApplicationConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
+@Import(ApplicationConfig.class)
 public class ToouApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/Toou/Toou/config/ApplicationConfig.java
+++ b/src/main/java/com/Toou/Toou/config/ApplicationConfig.java
@@ -1,0 +1,12 @@
+package com.Toou.Toou.config;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@Configuration
+@EntityScan(basePackages = "com.Toou.Toou.adapter.mysql.entity")
+@EnableJpaRepositories(basePackages = "com.Toou.Toou.adapter.mysql")
+public class ApplicationConfig {
+
+}

--- a/src/main/java/com/Toou/Toou/config/SwaggerConfig.java
+++ b/src/main/java/com/Toou/Toou/config/SwaggerConfig.java
@@ -1,0 +1,55 @@
+package com.Toou.Toou.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+	@Bean
+	public OpenAPI openAPI() {
+		List<Server> servers = createServers();
+
+		return new OpenAPI()
+				.info(apiInfo())
+				.servers(servers);
+//				.addSecurityItem(createSecurityRequirement())  //TODO: 인증 구현 이후 주석 해제
+//				.components(createComponents());
+	}
+
+	private List<Server> createServers() {
+		List<Server> servers = new ArrayList<>();
+		servers.add(new Server().url("http://toou.kro.kr/"));
+		servers.add(new Server().url("http://localhost:8080/"));
+		return servers;
+	}
+
+	private Info apiInfo() {
+		return new Info()
+				.title("Toou API 명세")
+				.description("잘못된 부분이나 오류 발생 시 바로 말씀해주세요.") // 문서 설명
+				.version("0.0.1");
+	}
+
+	private SecurityRequirement createSecurityRequirement() {
+		String jwtSchemeName = "Authorization";
+		return new SecurityRequirement().addList(jwtSchemeName);
+	}
+
+	private Components createComponents() {
+		String jwtSchemeName = "Authorization";
+		return new Components().addSecuritySchemes(jwtSchemeName,
+				new SecurityScheme()
+						.name(jwtSchemeName)
+						.in(SecurityScheme.In.HEADER)
+						.type(SecurityScheme.Type.APIKEY));
+	}
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,2 @@
+server:
+  port: 8080

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,2 @@
+server:
+  port: 8080

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=Toou

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,11 @@
+spring:
+  application:
+    name: toou
+  profiles:
+    default: local
+---
+spring:
+  config:
+    activate:
+      on-profile: local, prod
+    import: classpath:application-private.yml


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type[#issue number]: 작업 내용 -->
<!-- ex) feat[#133]: canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->


## 작업 개요
- application.yml 수정
- 스웨거 의존성 추가

## 작업 사항
- 기존에 있는 properties 대신 yml으로 수정했어요.
- profile에 따라서 다르게 실행되도록 application.yml을 추가했어요. 기본적으로 local로 실행되고, 배포된 서버에서는 Dockefile에 명시된대로 prod로 실행돼요. 각 profile에 따라서 application-local, applicaiton-prod의 값을 사용하게 돼요.
- 스웨거 의존성으로 추가했어요. 자동으로 컨트롤러, dto를 인식해서 만들어주고, 서버를 구분해서 실행할 수 있어요. 배포되면 `http://localhost:8080/swagger-ui/index.html` 로 스웨거에 들어갈 수 있어요ㄹ

## 스크린샷
![image](https://github.com/user-attachments/assets/3841c17b-0066-4031-a3b3-49d0624d045e)
