### PR TITLE
feat[#9]: /stocks/ 더미 데이터 보내주도록 구현

### DIFF
--- a/src/main/java/com/Toou/Toou/domain/model/StockMetadata.java
+++ b/src/main/java/com/Toou/Toou/domain/model/StockMetadata.java
@@ -1,0 +1,15 @@
+package com.Toou.Toou.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class StockMetadata {
+
+	private Long id;
+	private String stockCode;
+	private String stockName;
+}

--- a/src/main/java/com/Toou/Toou/port/in/dto/StockMetadataDto.java
+++ b/src/main/java/com/Toou/Toou/port/in/dto/StockMetadataDto.java
@@ -1,0 +1,20 @@
+package com.Toou.Toou.port.in.dto;
+
+import com.Toou.Toou.domain.model.StockMetadata;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class StockMetadataDto {
+
+	private String stockCode;
+	private String stockName;
+
+	public static StockMetadataDto fromDomainModel(StockMetadata domainModel) {
+		return new StockMetadataDto(
+				domainModel.getStockCode(),
+				domainModel.getStockName()
+		);
+	}
+}

--- a/src/main/java/com/Toou/Toou/port/in/dto/StockSearchListResponse.java
+++ b/src/main/java/com/Toou/Toou/port/in/dto/StockSearchListResponse.java
@@ -1,0 +1,13 @@
+package com.Toou.Toou.port.in.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@AllArgsConstructor
+@Data
+public class StockSearchListResponse {
+
+	private boolean ok;
+	private List<StockMetadataDto> stockSearchList;
+}

--- a/src/main/java/com/Toou/Toou/usecase/ListStockMetadataService.java
+++ b/src/main/java/com/Toou/Toou/usecase/ListStockMetadataService.java
@@ -1,0 +1,24 @@
+package com.Toou.Toou.usecase;
+
+import com.Toou.Toou.domain.model.StockMetadata;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ListStockMetadataService implements ListStockMetadataUseCase {
+
+	@Override
+	public Output execute(Input input) {
+		List<StockMetadata> duummyStokMetadataList = List.of(
+				new StockMetadata(1L, "A079980", "휴비스"),
+				new StockMetadata(2L, "A065510", "휴비츠"),
+				new StockMetadata(3L, "A215090", "휴센텍"),
+				new StockMetadata(4L, "A005010", "휴스틸")
+		);
+		return new Output(duummyStokMetadataList);
+
+		//TODO: input에서 주식 이름 받아와서 검색해서 리턴.
+	}
+}

--- a/src/main/java/com/Toou/Toou/usecase/ListStockMetadataUseCase.java
+++ b/src/main/java/com/Toou/Toou/usecase/ListStockMetadataUseCase.java
@@ -1,0 +1,26 @@
+package com.Toou.Toou.usecase;
+
+import com.Toou.Toou.domain.model.StockMetadata;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+public interface ListStockMetadataUseCase {
+
+	Output execute(Input input);
+
+	@AllArgsConstructor
+	@Data
+	class Input {
+
+		String stockName;
+		int limit;
+	}
+
+	@AllArgsConstructor
+	@Data
+	class Output {
+
+		List<StockMetadata> stokMetadataList;
+	}
+}


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type[#issue number]: 작업 내용 -->
<!-- ex) feat[#133]: canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

resolved: #9 

## 작업 개요
- /stocks 로 요청을 보낼때 더미 응답을 보내게 했어요

## 작업 사항
- 쿼리 파라미터로 종목 이름를 필수적으로, 개수를 선택적으로 입력받아서 종목 코드, 종목 명을 리스트로 보내는 api를 작성했습니다. 
- 더미데이터를 보낼때는 파라미터 값들에 상관없이 똑같은 데이터를 보내게 했습니다.

## 고민한 점들
### 요청 파라미터, post data에 상관없이 똑같은 데이터를 보내도 되는지
유즈케이스에서 파라미터 값으로 동작하지는 않고 똑같은 데이터를 보내게 했는데, 다른 api도 이렇게 진행해도 될까요?

## 스크린샷
![image](https://github.com/user-attachments/assets/624d47d7-eefc-4f6e-a002-a12767feb50a)
![image](https://github.com/user-attachments/assets/962c7cd5-8ae4-4339-8327-c17078833b84)

