### PR TITLE
feat[#13]: /accounts/assets, user 더미 데이터

### DIFF
--- a/src/main/java/com/Toou/Toou/domain/model/AccountAsset.java
+++ b/src/main/java/com/Toou/Toou/domain/model/AccountAsset.java
@@ -1,0 +1,20 @@
+package com.Toou.Toou.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class AccountAsset {
+
+	private Long id;
+	private Long totalAsset;
+	private Long deposit;
+	private Long totalHoldingsValue;
+	private Long totalHoldingsQuantity;
+	private Double investmentYield;
+}

--- a/src/main/java/com/Toou/Toou/domain/model/UserAccount.java
+++ b/src/main/java/com/Toou/Toou/domain/model/UserAccount.java
@@ -1,0 +1,17 @@
+package com.Toou.Toou.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class UserAccount {
+
+	private Long id;
+	private String kakaoId;
+	private String email;
+	private String username;
+	private String profileImageUrl;
+}

--- a/src/main/java/com/Toou/Toou/port/in/AccountController.java
+++ b/src/main/java/com/Toou/Toou/port/in/AccountController.java
@@ -38,11 +38,6 @@ public class AccountController {
 		return ResponseEntity.ok().body(response);
 	}
 
-	@GetMapping("/deposit")
-	ResponseEntity<String> deposit() {
-		return ResponseEntity.ok("deposit");
-	}
-
 	@GetMapping("/holdings")
 	ResponseEntity<String> holdingListStock() {
 		return ResponseEntity.ok("deposit");
@@ -51,11 +46,6 @@ public class AccountController {
 	@GetMapping("/stocks/{stockCode}/sellable")
 	ResponseEntity<String> sellableStockCount(@PathVariable String stockCode) {
 		return ResponseEntity.ok("sellableStockCount");
-	}
-
-	@GetMapping("/yield")
-	ResponseEntity<String> yield() {
-		return ResponseEntity.ok("yield");
 	}
 
 	@PostMapping("/stocks/{stockCode}/buy")

--- a/src/main/java/com/Toou/Toou/port/in/AccountController.java
+++ b/src/main/java/com/Toou/Toou/port/in/AccountController.java
@@ -1,0 +1,71 @@
+package com.Toou.Toou.port.in;
+
+import com.Toou.Toou.domain.model.UserAccount;
+import com.Toou.Toou.port.in.dto.AccountAssetResponse;
+import com.Toou.Toou.port.in.dto.UserAccountResponse;
+import com.Toou.Toou.usecase.AccountAssetUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/accounts")
+public class AccountController {
+
+	private final AccountAssetUseCase accountAssetUseCase;
+
+	private static final UserAccount DUMMY_USER_ACCOUNT = new UserAccount(
+			1L, "kakaoId", "test@example.com", "testuser", ""
+	);
+
+
+	@GetMapping("/user")
+	ResponseEntity<UserAccountResponse> userAccount() {
+		UserAccountResponse response = UserAccountResponse.fromDomainModel(DUMMY_USER_ACCOUNT);
+		return ResponseEntity.ok().body(response);
+	}
+
+	@GetMapping("/assets")
+	ResponseEntity<AccountAssetResponse> asset() {
+		AccountAssetUseCase.Input input = new AccountAssetUseCase.Input(DUMMY_USER_ACCOUNT);
+		AccountAssetUseCase.Output output = accountAssetUseCase.execute(input);
+		AccountAssetResponse response = AccountAssetResponse.fromDomainModel(output.getAccountAsset());
+		return ResponseEntity.ok().body(response);
+	}
+
+	@GetMapping("/deposit")
+	ResponseEntity<String> deposit() {
+		return ResponseEntity.ok("deposit");
+	}
+
+	@GetMapping("/holdings")
+	ResponseEntity<String> holdingListStock() {
+		return ResponseEntity.ok("deposit");
+	}
+
+	@GetMapping("/stocks/{stockCode}/sellable")
+	ResponseEntity<String> sellableStockCount(@PathVariable String stockCode) {
+		return ResponseEntity.ok("sellableStockCount");
+	}
+
+	@GetMapping("/yield")
+	ResponseEntity<String> yield() {
+		return ResponseEntity.ok("yield");
+	}
+
+	@PostMapping("/stocks/{stockCode}/buy")
+	ResponseEntity<String> buyStock(@PathVariable String stockCode) {
+		return ResponseEntity.ok("yield");
+	}
+
+	@PostMapping("/stocks/{stockCode}/sell")
+	ResponseEntity<String> sellStock(@PathVariable String stockCode) {
+		return ResponseEntity.ok("yield");
+	}
+
+}

--- a/src/main/java/com/Toou/Toou/port/in/dto/AccountAssetResponse.java
+++ b/src/main/java/com/Toou/Toou/port/in/dto/AccountAssetResponse.java
@@ -1,0 +1,28 @@
+package com.Toou.Toou.port.in.dto;
+
+import com.Toou.Toou.domain.model.AccountAsset;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@AllArgsConstructor
+@Data
+public class AccountAssetResponse {
+
+	private boolean ok;
+	private Long totalAsset;
+	private Long deposit;
+	private Long totalHoldingsValue;
+	private Long totalHoldingsQuantity;
+	private Double investmentYield;
+
+	public static AccountAssetResponse fromDomainModel(AccountAsset accountAsset) {
+		return new AccountAssetResponse(
+				true,
+				accountAsset.getTotalAsset(),
+				accountAsset.getDeposit(),
+				accountAsset.getTotalHoldingsValue(),
+				accountAsset.getTotalHoldingsQuantity(),
+				accountAsset.getInvestmentYield()
+		);
+	}
+}

--- a/src/main/java/com/Toou/Toou/port/in/dto/UserAccountResponse.java
+++ b/src/main/java/com/Toou/Toou/port/in/dto/UserAccountResponse.java
@@ -1,0 +1,26 @@
+package com.Toou.Toou.port.in.dto;
+
+import com.Toou.Toou.domain.model.UserAccount;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@AllArgsConstructor
+@Data
+public class UserAccountResponse {
+
+	private Long id;
+	private String kakaoId;
+	private String email;
+	private String username;
+	private String profileImageUrl;
+
+	public static UserAccountResponse fromDomainModel(UserAccount userAccount) {
+		return new UserAccountResponse(
+				userAccount.getId(),
+				userAccount.getKakaoId(),
+				userAccount.getEmail(),
+				userAccount.getUsername(),
+				userAccount.getProfileImageUrl()
+		);
+	}
+}

--- a/src/main/java/com/Toou/Toou/usecase/AccountAssetService.java
+++ b/src/main/java/com/Toou/Toou/usecase/AccountAssetService.java
@@ -1,0 +1,26 @@
+package com.Toou.Toou.usecase;
+
+import com.Toou.Toou.domain.model.AccountAsset;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AccountAssetService implements AccountAssetUseCase {
+
+	private static final AccountAsset DUMMY_ACCOUNT_ASSET = AccountAsset.builder()
+			.id(1L)
+			.deposit(50000000L)
+			.investmentYield(12.56)
+			.totalAsset(150000000L)
+			.totalHoldingsQuantity(3L)
+			.totalHoldingsValue(7000000L)
+			.build();
+
+	@Transactional
+	@Override
+	public AccountAssetUseCase.Output execute(AccountAssetUseCase.Input input) {
+		return new Output(DUMMY_ACCOUNT_ASSET);
+	}
+}

--- a/src/main/java/com/Toou/Toou/usecase/AccountAssetUseCase.java
+++ b/src/main/java/com/Toou/Toou/usecase/AccountAssetUseCase.java
@@ -1,0 +1,25 @@
+package com.Toou.Toou.usecase;
+
+import com.Toou.Toou.domain.model.AccountAsset;
+import com.Toou.Toou.domain.model.UserAccount;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+public interface AccountAssetUseCase {
+
+	AccountAssetUseCase.Output execute(AccountAssetUseCase.Input input);
+
+	@AllArgsConstructor
+	@Data
+	class Input {
+
+		UserAccount userAccount;
+	}
+
+	@AllArgsConstructor
+	@Data
+	class Output {
+
+		AccountAsset accountAsset;
+	}
+}


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type[#issue number]: 작업 내용 -->
<!-- ex) feat[#133]: canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

resolved: <!-- #이슈번호. 머지되면 이슈가 종료됨-->

## 작업 개요
- /accounts/assets, /accounts/user 경로로 더미 데이터 보내주는 api
- 구현해야할 account controller 뼈대

## 작업 사항
1. /accounts api 뼈대 : api 명세에 나온 필요한 api들을 일단 명시해두었어요. 응답 샘플에 string이라고 나오면 더미 데이터 보내주는 걸 구현하지 않은 상태입니다.
2. /accounts/user : asset을 가져올때 user 정보로 가져올 것을 예상해서 UserAccount 도메인 모델을 만들었는데, 만든 김에 보여줄 수 있는 데이터 알려줄 용도로 만들었어요. 카카오 OAuth 도입할때 더 많은 데이터를 가져올수 있는것 같아요
3. /accounts/assets : AccountAsset으로 도메인 모델 만들고 정보 그대로 보여주도록 작성했어요