### PR TITLE
refactor[#13]: 서비스에서 더미 데이터 사용하는 것 변경

### DIFF
--- a/src/main/java/com/Toou/Toou/usecase/ListStockHistoryService.java
+++ b/src/main/java/com/Toou/Toou/usecase/ListStockHistoryService.java
@@ -22,12 +22,13 @@ public class ListStockHistoryService implements ListStockHistoryUseCase {
 	private final StockHistoryPort stockHistoryPort;
 	private final StockOpenApiPort stockOpenApiPort;
 
+	private static final List<StockDailyHistory> DUMMY_DAILY_HISTORIES = parseDummyCsvData();
+
 	@Transactional
 	@Override
 	public Output execute(Input input) {
 		//TODO: 더미데이터. 구현 후 삭제
-		List<StockDailyHistory> dummyDailyHistories = parseDummyCsvData();
-		return new Output(dummyDailyHistories);
+		return new Output(DUMMY_DAILY_HISTORIES);
 
 //		List<StockDailyHistory> dailyHistories = stockHistoryPort.findAllHistoriesBetweenDates(
 //				input.stockCode, input.dateFrom, input.dateTo);
@@ -44,7 +45,7 @@ public class ListStockHistoryService implements ListStockHistoryUseCase {
 		return false;
 	}
 
-	private List<StockDailyHistory> parseDummyCsvData() {
+	private static List<StockDailyHistory> parseDummyCsvData() {
 		List<StockDailyHistory> stockDailyHistories = new ArrayList<>();
 		BufferedReader reader = new BufferedReader(new StringReader(dummyCsv()));
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
@@ -70,7 +71,7 @@ public class ListStockHistoryService implements ListStockHistoryUseCase {
 		return stockDailyHistories;
 	}
 
-	private String dummyCsv() {
+	private static String dummyCsv() {
 		return """
 				날짜,시가,고가,저가,종가,거래량,등락률
 				2023-01-02,4960,4960,4705,4800,20898,-1.7400204708290685

--- a/src/main/java/com/Toou/Toou/usecase/ListStockMetadataService.java
+++ b/src/main/java/com/Toou/Toou/usecase/ListStockMetadataService.java
@@ -9,16 +9,16 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ListStockMetadataService implements ListStockMetadataUseCase {
 
+	private static final List<StockMetadata> DUMMY_STOCK_METADATA_LIST = List.of(
+			new StockMetadata(1L, "A079980", "휴비스"),
+			new StockMetadata(2L, "A065510", "휴비츠"),
+			new StockMetadata(3L, "A215090", "휴센텍"),
+			new StockMetadata(4L, "A005010", "휴스틸")
+	);
+
 	@Override
 	public Output execute(Input input) {
-		List<StockMetadata> duummyStokMetadataList = List.of(
-				new StockMetadata(1L, "A079980", "휴비스"),
-				new StockMetadata(2L, "A065510", "휴비츠"),
-				new StockMetadata(3L, "A215090", "휴센텍"),
-				new StockMetadata(4L, "A005010", "휴스틸")
-		);
-		return new Output(duummyStokMetadataList);
-
+		return new Output(DUMMY_STOCK_METADATA_LIST);
 		//TODO: input에서 주식 이름 받아와서 검색해서 리턴.
 	}
 }


### PR DESCRIPTION
서비스 안에서 전체적으로 사용할 dummy를 나중에 제거하기 쉽게 private static final 으로 선언하고 사용하도록 변경

<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type[#issue number]: 작업 내용 -->
<!-- ex) feat[#133]: canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->


## 작업 개요
- stocks 서비스 리팩토링

## 작업 사항
- 나중에 더미 데이터 지우기 쉽게 정적 클래스 변수 만들어서 사용하도록 했어요