### PR TITLE
feat[#18]: 매수, 매도 가능 수량 더미 api

### DIFF
--- a/src/main/java/com/Toou/Toou/domain/model/StockBuyable.java
+++ b/src/main/java/com/Toou/Toou/domain/model/StockBuyable.java
@@ -1,0 +1,18 @@
+package com.Toou.Toou.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class StockBuyable {
+
+	private Long id;
+	private String stockCode;
+	private String stockName;
+	private Long stockPrice;
+	private Long deposit;
+	private Long buyableQuantity;
+}

--- a/src/main/java/com/Toou/Toou/domain/model/StockSellable.java
+++ b/src/main/java/com/Toou/Toou/domain/model/StockSellable.java
@@ -1,0 +1,16 @@
+package com.Toou.Toou.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class StockSellable {
+
+	private Long id;
+	private String stockCode;              // 종목 코드
+	private String stockName;              // 종목명
+	private Long sellableQuantity;
+}

--- a/src/main/java/com/Toou/Toou/port/in/AccountController.java
+++ b/src/main/java/com/Toou/Toou/port/in/AccountController.java
@@ -4,9 +4,12 @@ import com.Toou.Toou.domain.model.UserAccount;
 import com.Toou.Toou.port.in.dto.AccountAssetResponse;
 import com.Toou.Toou.port.in.dto.HoldingIndividualDto;
 import com.Toou.Toou.port.in.dto.HoldingListResponse;
+import com.Toou.Toou.port.in.dto.OrderableQuantityResponse;
 import com.Toou.Toou.port.in.dto.UserAccountResponse;
 import com.Toou.Toou.usecase.AccountAssetUseCase;
 import com.Toou.Toou.usecase.AccountHoldingUseCase;
+import com.Toou.Toou.usecase.BuyableStockUseCase;
+import com.Toou.Toou.usecase.SellableStockUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,6 +25,8 @@ public class AccountController {
 
 	private final AccountAssetUseCase accountAssetUseCase;
 	private final AccountHoldingUseCase accountHoldingUseCase;
+	private final SellableStockUseCase sellableStockUseCase;
+	private final BuyableStockUseCase buyableStockUseCase;
 
 	private static final UserAccount DUMMY_USER_ACCOUNT = new UserAccount(
 			1L, "kakaoId", "test@example.com", "testuser", ""
@@ -52,8 +57,23 @@ public class AccountController {
 	}
 
 	@GetMapping("/stocks/{stockCode}/sellable")
-	ResponseEntity<String> sellableStockCount(@PathVariable String stockCode) {
-		return ResponseEntity.ok("sellableStockCount");
+	ResponseEntity<OrderableQuantityResponse> sellableStockCount(@PathVariable String stockCode) {
+		SellableStockUseCase.Input input = new SellableStockUseCase.Input(stockCode,
+				DUMMY_USER_ACCOUNT);
+		SellableStockUseCase.Output output = sellableStockUseCase.execute(input);
+		OrderableQuantityResponse response = OrderableQuantityResponse.fromDomainModel(
+				output.getStockSellable());
+		return ResponseEntity.ok().body(response);
+	}
+
+	@GetMapping("/stocks/{stockCode}/buyable")
+	ResponseEntity<OrderableQuantityResponse> buyableStockCount(@PathVariable String stockCode) {
+		BuyableStockUseCase.Input input = new BuyableStockUseCase.Input(stockCode,
+				DUMMY_USER_ACCOUNT);
+		BuyableStockUseCase.Output output = buyableStockUseCase.execute(input);
+		OrderableQuantityResponse response = OrderableQuantityResponse.fromDomainModel(
+				output.getStockBuyable());
+		return ResponseEntity.ok().body(response);
 	}
 
 	@PostMapping("/stocks/{stockCode}/buy")

--- a/src/main/java/com/Toou/Toou/port/in/dto/OrderableQuantityResponse.java
+++ b/src/main/java/com/Toou/Toou/port/in/dto/OrderableQuantityResponse.java
@@ -1,0 +1,36 @@
+package com.Toou.Toou.port.in.dto;
+
+import com.Toou.Toou.domain.model.StockBuyable;
+import com.Toou.Toou.domain.model.StockSellable;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@AllArgsConstructor
+@Data
+public class OrderableQuantityResponse {
+
+	private final Boolean ok;
+
+	@Schema(description = "종목명")
+	private String stockName;
+
+	@Schema(description = "매수/매도 가능 수량")
+	private Long quantity;
+
+	public static OrderableQuantityResponse fromDomainModel(StockSellable domainModel) {
+		return new OrderableQuantityResponse(
+				true,
+				domainModel.getStockName(),
+				domainModel.getSellableQuantity()
+		);
+	}
+
+	public static OrderableQuantityResponse fromDomainModel(StockBuyable domainModel) {
+		return new OrderableQuantityResponse(
+				true,
+				domainModel.getStockName(),
+				domainModel.getBuyableQuantity()
+		);
+	}
+}

--- a/src/main/java/com/Toou/Toou/port/in/dto/StockOrderRequest.java
+++ b/src/main/java/com/Toou/Toou/port/in/dto/StockOrderRequest.java
@@ -1,0 +1,12 @@
+package com.Toou.Toou.port.in.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class StockOrderRequest {
+
+	private Long stockPrice;
+	private Long orderQuantity;
+}

--- a/src/main/java/com/Toou/Toou/usecase/BuyableStockService.java
+++ b/src/main/java/com/Toou/Toou/usecase/BuyableStockService.java
@@ -1,0 +1,19 @@
+package com.Toou.Toou.usecase;
+
+import com.Toou.Toou.domain.model.StockBuyable;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BuyableStockService implements BuyableStockUseCase {
+
+	private static final StockBuyable stockBuyable = new StockBuyable(
+			1L, "A079980", "휴비스", 5670L, 100000L, 10L
+	);
+
+	@Override
+	public Output execute(Input input) {
+		return new Output(stockBuyable);
+	}
+}

--- a/src/main/java/com/Toou/Toou/usecase/BuyableStockUseCase.java
+++ b/src/main/java/com/Toou/Toou/usecase/BuyableStockUseCase.java
@@ -1,0 +1,26 @@
+package com.Toou.Toou.usecase;
+
+import com.Toou.Toou.domain.model.StockBuyable;
+import com.Toou.Toou.domain.model.UserAccount;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+public interface BuyableStockUseCase {
+
+	BuyableStockUseCase.Output execute(BuyableStockUseCase.Input input);
+
+	@AllArgsConstructor
+	@Data
+	class Input {
+
+		String stockCode;
+		UserAccount userAccount;
+	}
+
+	@AllArgsConstructor
+	@Data
+	class Output {
+
+		StockBuyable stockBuyable;
+	}
+}

--- a/src/main/java/com/Toou/Toou/usecase/SellableStockService.java
+++ b/src/main/java/com/Toou/Toou/usecase/SellableStockService.java
@@ -1,0 +1,19 @@
+package com.Toou.Toou.usecase;
+
+import com.Toou.Toou.domain.model.StockSellable;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SellableStockService implements SellableStockUseCase {
+
+	private static final StockSellable stockSellable = new StockSellable(
+			1L, "A079980", "휴비스", 10L
+	);
+
+	@Override
+	public Output execute(Input input) {
+		return new Output(stockSellable);
+	}
+}

--- a/src/main/java/com/Toou/Toou/usecase/SellableStockUseCase.java
+++ b/src/main/java/com/Toou/Toou/usecase/SellableStockUseCase.java
@@ -1,0 +1,26 @@
+package com.Toou.Toou.usecase;
+
+import com.Toou.Toou.domain.model.StockSellable;
+import com.Toou.Toou.domain.model.UserAccount;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+public interface SellableStockUseCase {
+
+	SellableStockUseCase.Output execute(SellableStockUseCase.Input input);
+
+	@AllArgsConstructor
+	@Data
+	class Input {
+
+		String stockCode;
+		UserAccount userAccount;
+	}
+
+	@AllArgsConstructor
+	@Data
+	class Output {
+
+		StockSellable stockSellable;
+	}
+}


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type[#issue number]: 작업 내용 -->
<!-- ex) feat[#133]: canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->


## 작업 개요
- /api/accounts/stocks/2/sellable : 매도 가능 수량
- /api/accounts/stocks/2/buyable : 매수 가능 수량

## 작업 사항
더미 데이터 보내주는 api 작성했어요.
api 명세서에는 sellable만 있었는데, 매수 가능 수량도 필요할것 같아서 추가했습니다.

도메인 모델은 다르지만, 주문 가능 수량이라는 측면에서 응답 객체를 동일하게 작성했어요.
(커밋 메세지에는 요청 dto도 동일하다고 했지만, 주문에서 사용할 공통 요청을 잘못 넣었어요ㅠㅠ)