### PR TITLE
feat[#18]: 주문 더미 api, enum 불일치 예외 처리

### DIFF
--- a/src/main/java/com/Toou/Toou/domain/model/StockOrder.java
+++ b/src/main/java/com/Toou/Toou/domain/model/StockOrder.java
@@ -1,0 +1,20 @@
+package com.Toou.Toou.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class StockOrder {
+
+	private String stockCode;
+	private String stockName;
+	private Long stockPrice;
+	private Long orderQuantity;
+	private TradeType tradeType;
+	private UserAccount userAccount;
+}

--- a/src/main/java/com/Toou/Toou/domain/model/TradeType.java
+++ b/src/main/java/com/Toou/Toou/domain/model/TradeType.java
@@ -1,0 +1,19 @@
+package com.Toou.Toou.domain.model;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum TradeType {
+	BUY("buy"),
+	SELL("sell");
+
+	private final String type;
+
+	TradeType(String type) {
+		this.type = type;
+	}
+
+	@JsonValue
+	public String value() {
+		return type;
+	}
+}

--- a/src/main/java/com/Toou/Toou/exception/CustomException.java
+++ b/src/main/java/com/Toou/Toou/exception/CustomException.java
@@ -1,0 +1,12 @@
+package com.Toou.Toou.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomException extends RuntimeException {
+
+	private final String type;
+	private final String message;
+}

--- a/src/main/java/com/Toou/Toou/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/Toou/Toou/exception/CustomExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.Toou.Toou.exception;
+
+import com.Toou.Toou.port.in.dto.CustomErrorResponse;
+import com.Toou.Toou.port.in.dto.ErrorDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice()
+public class CustomExceptionHandler {
+
+	@ExceptionHandler(CustomException.class)
+	public ResponseEntity<CustomErrorResponse> handleCustomException(CustomException ex) {
+		CustomErrorResponse errorResponse = new CustomErrorResponse(
+				new ErrorDetails(ex.getType(), ex.getMessage()));
+		return ResponseEntity.ok(errorResponse); //errorResponse 의 ok 값으로 에러 여부 구분.
+	}
+}

--- a/src/main/java/com/Toou/Toou/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/Toou/Toou/exception/GlobalExceptionHandler.java
@@ -1,0 +1,36 @@
+package com.Toou.Toou.exception;
+
+import com.Toou.Toou.port.in.dto.CustomErrorResponse;
+import com.Toou.Toou.port.in.dto.ErrorDetails;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import java.util.Arrays;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice()
+public class GlobalExceptionHandler {
+	
+	@ExceptionHandler(InvalidFormatException.class) // Enum 변환 실패할때.
+	public ResponseEntity<CustomErrorResponse> handleInvalidFormatException(
+			InvalidFormatException ex) {
+		String fieldName = ex.getPath().get(0).getFieldName();
+		String errorMessage = "";
+
+		Class<?> targetType = ex.getTargetType();
+		if (targetType.isEnum()) {
+			String validValues = "";
+			validValues = String.join(", ", Arrays.stream(targetType.getEnumConstants())
+					.map(Object::toString)
+					.toArray(String[]::new));
+			errorMessage = "요청의 다음 속성의 값이 유효한 값이 아닙니다. 속성: " + fieldName + ", 값: " + ex.getValue() +
+					". 가능한 값: " + validValues;
+		} else {
+			errorMessage = "요청의 다음 속성의 값이 유효한 값이 아닙니다. 속성 : " + fieldName + ", 값 : " + ex.getValue();
+		}
+
+		CustomErrorResponse response = new CustomErrorResponse(
+				new ErrorDetails("validation_fail", errorMessage));
+		return ResponseEntity.ok().body(response);
+	}
+}

--- a/src/main/java/com/Toou/Toou/port/in/dto/CustomErrorResponse.java
+++ b/src/main/java/com/Toou/Toou/port/in/dto/CustomErrorResponse.java
@@ -1,0 +1,12 @@
+package com.Toou.Toou.port.in.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class CustomErrorResponse {
+
+	private final Boolean ok = false;
+	private final ErrorDetails error;
+}

--- a/src/main/java/com/Toou/Toou/port/in/dto/ErrorDetails.java
+++ b/src/main/java/com/Toou/Toou/port/in/dto/ErrorDetails.java
@@ -1,0 +1,18 @@
+package com.Toou.Toou.port.in.dto;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorDetails {
+
+
+	@Schema(description = "에러 타입")
+	private final String type;
+
+	@Schema(description = "에러 설명")
+	private final String message;
+}

--- a/src/main/java/com/Toou/Toou/port/in/dto/StockOrderRequest.java
+++ b/src/main/java/com/Toou/Toou/port/in/dto/StockOrderRequest.java
@@ -1,5 +1,7 @@
 package com.Toou.Toou.port.in.dto;
 
+import com.Toou.Toou.domain.model.TradeType;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -7,6 +9,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class StockOrderRequest {
 
+	@NotNull
 	private Long stockPrice;
+
+	@NotNull
 	private Long orderQuantity;
+
+	@NotNull
+	private TradeType tradeType;
 }

--- a/src/main/java/com/Toou/Toou/port/in/dto/StockOrderRequest.java
+++ b/src/main/java/com/Toou/Toou/port/in/dto/StockOrderRequest.java
@@ -1,6 +1,7 @@
 package com.Toou.Toou.port.in.dto;
 
 import com.Toou.Toou.domain.model.TradeType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,12 +10,15 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class StockOrderRequest {
 
+	@Schema(description = "주식 가격")
 	@NotNull
 	private Long stockPrice;
 
+	@Schema(description = "주문하려는 수량")
 	@NotNull
 	private Long orderQuantity;
 
+	@Schema(description = "주문 타입(매수/매도)")
 	@NotNull
 	private TradeType tradeType;
 }

--- a/src/main/java/com/Toou/Toou/port/in/dto/VoidResponse.java
+++ b/src/main/java/com/Toou/Toou/port/in/dto/VoidResponse.java
@@ -1,0 +1,15 @@
+package com.Toou.Toou.port.in.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@AllArgsConstructor
+@Data
+public class VoidResponse {
+
+	private final Boolean ok;
+
+	public static VoidResponse ok() {
+		return new VoidResponse(Boolean.TRUE);
+	}
+}

--- a/src/main/java/com/Toou/Toou/usecase/StockOrderService.java
+++ b/src/main/java/com/Toou/Toou/usecase/StockOrderService.java
@@ -1,0 +1,14 @@
+package com.Toou.Toou.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StockOrderService implements StockOrderUseCase {
+
+	@Override
+	public Output execute(Input input) {
+		return new Output();
+	}
+}

--- a/src/main/java/com/Toou/Toou/usecase/StockOrderUseCase.java
+++ b/src/main/java/com/Toou/Toou/usecase/StockOrderUseCase.java
@@ -1,0 +1,23 @@
+package com.Toou.Toou.usecase;
+
+import com.Toou.Toou.domain.model.StockOrder;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+public interface StockOrderUseCase {
+
+	StockOrderUseCase.Output execute(StockOrderUseCase.Input input);
+
+	@AllArgsConstructor
+	@Data
+	class Input {
+
+		StockOrder stockOrder;
+	}
+
+	@AllArgsConstructor
+	@Data
+	class Output {
+
+	}
+}


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type[#issue number]: 작업 내용 -->
<!-- ex) feat[#133]: canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

resolved: #18 

## 작업 개요
- 매수, 매도 더미 api
- request body의 속성 중 Enum 타입 예외 처리

## 작업 사항
tradeType 속성에 BUY, SELL로 주문을 받도록 처리했어요. 잘못된 값을 보냈을 경우, 프론트에서 해당하는 값을 알 수 있도록 가능한 값을 응답으로 보내도록 작성했어요.

예외 처리가는 김에 추가로 Custom Exception을 처리하는 코드도 작성했어요

## 스크린샷
![image](https://github.com/user-attachments/assets/c08404b0-b586-4106-b08e-2595b299eccc)
