### PR TITLE
feat[#24]: DB로 종목 명 검색

### DIFF
--- a/src/main/java/com/Toou/Toou/adapter/mysql/StockMetadataAdapter.java
+++ b/src/main/java/com/Toou/Toou/adapter/mysql/StockMetadataAdapter.java
@@ -1,0 +1,36 @@
+package com.Toou.Toou.adapter.mysql;
+
+import com.Toou.Toou.adapter.mysql.entity.StockMetadataEntity;
+import com.Toou.Toou.domain.model.StockMetadata;
+import com.Toou.Toou.port.out.StockMetadataPort;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+//@Repository
+@Component
+@RequiredArgsConstructor
+public class StockMetadataAdapter implements StockMetadataPort {
+
+	private final StockMetadataRepository stockMetadataRepository;
+
+	@Override
+	public List<StockMetadata> searchStocksByStockName(String stockName, int limit) {
+		List<StockMetadataEntity> entities = stockMetadataRepository.findByStockNameContaining(
+				stockName);
+		return entities.stream()
+				.map(this::toDomainModel)
+				.limit(limit)
+				.collect(Collectors.toList());
+	}
+
+	private StockMetadata toDomainModel(StockMetadataEntity entity) {
+		return new StockMetadata(
+				entity.getId(),
+				entity.getStockCode(),
+				entity.getStockName(),
+				entity.getMarket()
+		);
+	}
+}

--- a/src/main/java/com/Toou/Toou/adapter/mysql/StockMetadataRepository.java
+++ b/src/main/java/com/Toou/Toou/adapter/mysql/StockMetadataRepository.java
@@ -1,0 +1,10 @@
+package com.Toou.Toou.adapter.mysql;
+
+import com.Toou.Toou.adapter.mysql.entity.StockMetadataEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StockMetadataRepository extends JpaRepository<StockMetadataEntity, Long> {
+
+	List<StockMetadataEntity> findByStockNameContaining(String stockName);
+}

--- a/src/main/java/com/Toou/Toou/adapter/mysql/entity/StockMetadataEntity.java
+++ b/src/main/java/com/Toou/Toou/adapter/mysql/entity/StockMetadataEntity.java
@@ -1,0 +1,41 @@
+package com.Toou.Toou.adapter.mysql.entity;
+
+import com.Toou.Toou.domain.model.MarketType;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+@Entity(name = "stock_metadata")
+public class StockMetadataEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "stock_code", nullable = false, unique = true)
+	private String stockCode;
+
+	@Column(name = "stock_name", nullable = false, unique = true)
+	private String stockName;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "market", nullable = false)
+	private MarketType market;
+
+	@OneToMany(mappedBy = "stockMetadata", cascade = CascadeType.ALL, orphanRemoval = true)
+	//부모 entity 변경시 삭제
+	private List<StockHistoryEntity> histories;
+}

--- a/src/main/java/com/Toou/Toou/domain/model/MarketType.java
+++ b/src/main/java/com/Toou/Toou/domain/model/MarketType.java
@@ -1,0 +1,21 @@
+package com.Toou.Toou.domain.model;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum MarketType {
+	KOSPI("KOSPI"),
+	KOSDAQ("KOSDAQ"),
+	KONEX("KONEX");
+
+	private final String value;
+
+	MarketType(String value) {
+		this.value = value;
+	}
+
+	@JsonValue
+	public String getValue() {
+		return value;
+	}
+
+}

--- a/src/main/java/com/Toou/Toou/domain/model/StockMetadata.java
+++ b/src/main/java/com/Toou/Toou/domain/model/StockMetadata.java
@@ -12,4 +12,5 @@ public class StockMetadata {
 	private Long id;
 	private String stockCode;
 	private String stockName;
+	private MarketType market;
 }

--- a/src/main/java/com/Toou/Toou/port/in/dto/StockMetadataDto.java
+++ b/src/main/java/com/Toou/Toou/port/in/dto/StockMetadataDto.java
@@ -1,5 +1,6 @@
 package com.Toou.Toou.port.in.dto;
 
+import com.Toou.Toou.domain.model.MarketType;
 import com.Toou.Toou.domain.model.StockMetadata;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -15,10 +16,14 @@ public class StockMetadataDto {
 	@Schema(description = "종목명")
 	private String stockName;
 
+	@Schema(description = "시장")
+	private MarketType market;
+
 	public static StockMetadataDto fromDomainModel(StockMetadata domainModel) {
 		return new StockMetadataDto(
 				domainModel.getStockCode(),
-				domainModel.getStockName()
+				domainModel.getStockName(),
+				domainModel.getMarket()
 		);
 	}
 }

--- a/src/main/java/com/Toou/Toou/port/out/StockMetadataPort.java
+++ b/src/main/java/com/Toou/Toou/port/out/StockMetadataPort.java
@@ -1,0 +1,9 @@
+package com.Toou.Toou.port.out;
+
+import com.Toou.Toou.domain.model.StockMetadata;
+import java.util.List;
+
+public interface StockMetadataPort {
+
+	List<StockMetadata> searchStocksByStockName(String stockName, int limit);
+}

--- a/src/main/java/com/Toou/Toou/usecase/ListStockMetadataService.java
+++ b/src/main/java/com/Toou/Toou/usecase/ListStockMetadataService.java
@@ -1,6 +1,7 @@
 package com.Toou.Toou.usecase;
 
 import com.Toou.Toou.domain.model.StockMetadata;
+import com.Toou.Toou.port.out.StockMetadataPort;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -9,16 +10,12 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ListStockMetadataService implements ListStockMetadataUseCase {
 
-	private static final List<StockMetadata> DUMMY_STOCK_METADATA_LIST = List.of(
-			new StockMetadata(1L, "A079980", "휴비스"),
-			new StockMetadata(2L, "A065510", "휴비츠"),
-			new StockMetadata(3L, "A215090", "휴센텍"),
-			new StockMetadata(4L, "A005010", "휴스틸")
-	);
+	private final StockMetadataPort stockMetadataPort;
 
 	@Override
 	public Output execute(Input input) {
-		return new Output(DUMMY_STOCK_METADATA_LIST);
-		//TODO: input에서 주식 이름 받아와서 검색해서 리턴.
+		List<StockMetadata> stockMetadatas = stockMetadataPort.searchStocksByStockName(
+				input.getStockName(), input.limit);
+		return new Output(stockMetadatas);
 	}
 }


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type[#issue number]: 작업 내용 -->
<!-- ex) feat[#133]: canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

resolved: #24 <!-- #이슈번호. 머지되면 이슈가 종료됨-->

## 작업 개요
- stock metadata에 상장된 시장 정보 추가
- DB에서 값 가져와서 보여주기

## 작업 사항
pykrx로 종목 코드를 가져오는 코드를 수정하는 중에 시장(코스피, 코스닥, 코넥스)에 따라서 가져올 수 있는것을 발견했어요. 그래서 시장 정보를 저장할 필요가 있어 보여서 추가했습니다.