### PR TITLE
feat[#130]: stock history 커스텀 예외와 응답

### DIFF
--- a/src/main/java/com/Toou/Toou/adapter/mysql/StockMetadataAdapter.java
+++ b/src/main/java/com/Toou/Toou/adapter/mysql/StockMetadataAdapter.java
@@ -6,10 +6,9 @@ import com.Toou.Toou.port.out.StockMetadataPort;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Repository;
 
-//@Repository
-@Component
+@Repository
 @RequiredArgsConstructor
 public class StockMetadataAdapter implements StockMetadataPort {
 

--- a/src/main/java/com/Toou/Toou/exception/CustomException.java
+++ b/src/main/java/com/Toou/Toou/exception/CustomException.java
@@ -9,4 +9,10 @@ public class CustomException extends RuntimeException {
 
 	private final String type;
 	private final String message;
+
+	public CustomException(CustomExceptionDetail exceptionDetail) {
+		super(exceptionDetail.getMessage());
+		this.type = exceptionDetail.getType();
+		this.message = exceptionDetail.getMessage();
+	}
 }

--- a/src/main/java/com/Toou/Toou/exception/CustomExceptionDetail.java
+++ b/src/main/java/com/Toou/Toou/exception/CustomExceptionDetail.java
@@ -1,0 +1,14 @@
+package com.Toou.Toou.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CustomExceptionDetail {
+	STOCK_NOT_FOUND("stock_not_found", "해당하는 주식 종목을 찾을 수 없습니다");
+
+	private final String type;
+	private final String message;
+
+}

--- a/src/main/java/com/Toou/Toou/port/in/StockController.java
+++ b/src/main/java/com/Toou/Toou/port/in/StockController.java
@@ -13,6 +13,8 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -28,8 +30,13 @@ public class StockController {
 	private final ListStockMetadataUseCase listStockMetadataUseCase;
 	private final ListStockHistoryUseCase listStockHistoryUseCase;
 
-	private final LocalDate DUMMY_START_DATE = LocalDate.of(2023, 1, 1);
-	private final LocalDate DUMMY_NEWEST_DATE = LocalDate.of(2023, 12, 31);
+	@Value("${dummy.start-date}")
+	@DateTimeFormat(pattern = "yyyy-MM-dd")
+	private LocalDate DUMMY_START_DATE;
+
+	@Value("${dummy.newest-date}")
+	@DateTimeFormat(pattern = "yyyy-MM-dd")
+	private LocalDate DUMMY_NEWEST_DATE;
 
 	@GetMapping
 	ResponseEntity<StockSearchListResponse> listStockMetadataByName(@RequestParam final String name,

--- a/src/main/java/com/Toou/Toou/port/in/StockController.java
+++ b/src/main/java/com/Toou/Toou/port/in/StockController.java
@@ -1,6 +1,8 @@
 package com.Toou.Toou.port.in;
 
 import com.Toou.Toou.domain.model.StockDailyHistory;
+import com.Toou.Toou.exception.CustomException;
+import com.Toou.Toou.exception.CustomExceptionDetail;
 import com.Toou.Toou.port.in.dto.StockDailyHistoryDto;
 import com.Toou.Toou.port.in.dto.StockHistoryListResponse;
 import com.Toou.Toou.port.in.dto.StockMetadataDto;
@@ -78,11 +80,11 @@ public class StockController {
 	private static boolean isValidDateRange(LocalDate dateFrom, LocalDate dateTo) {
 		return dateFrom.isEqual(dateTo) || dateFrom.isBefore(dateTo);
 	}
-	
+
 	private static StockHistoryListResponse buildStockHistoryListResponse(
 			List<StockDailyHistory> stockDailyHistories, LocalDate newestDate) {
 		StockDailyHistory firstHistory = stockDailyHistories.stream().findFirst()
-				.orElseThrow(() -> new IllegalStateException("No stock history found"));
+				.orElseThrow(() -> new CustomException(CustomExceptionDetail.STOCK_NOT_FOUND));
 		StockDailyHistory lastHistory = stockDailyHistories.get(stockDailyHistories.size() - 1);
 
 		return new StockHistoryListResponse(


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type[#issue number]: 작업 내용 -->
<!-- ex) feat[#133]: canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

resolved: #30 <!-- #이슈번호. 머지되면 이슈가 종료됨-->

## 작업 개요
- stock code로 받아온 history가 없을때 예외 발생 & 에러 응답
- 어댑터 어노테이션은 컴포넌트 -> 리포지토리로 변경
- 데이터베이스에 주식 가격이 저장되기 시작되는 날짜와 끝나는 날짜를 yml 파일에서 가져오도록 수정. (나중에 DB에 데이터 추가로 넣으면, 깃헙 액션 시크릿 값만 바꾸고 액션만 다시 돌려서 적용되도록)

## 작업 사항

**기타**
컨트롤러, 서비스 단에서 커스텀 예외를 발생시키면, 커스텀 예외 핸들러가 처리해서 에러 응답을 보내도록 했어요

## 스크린샷
![image](https://github.com/user-attachments/assets/668d056f-41c1-4fd8-9352-f1d94bba822b)

