### PR TITLE
feat[#33]: 매수, 매도 주문

### DIFF
--- a/src/main/java/com/Toou/Toou/adapter/mysql/StockOrderAdapter.java
+++ b/src/main/java/com/Toou/Toou/adapter/mysql/StockOrderAdapter.java
@@ -1,0 +1,96 @@
+package com.Toou.Toou.adapter.mysql;
+
+import com.Toou.Toou.adapter.mysql.entity.AccountAssetEntity;
+import com.Toou.Toou.adapter.mysql.entity.HoldingStockEntity;
+import com.Toou.Toou.domain.model.AccountAsset;
+import com.Toou.Toou.domain.model.StockOrder;
+import com.Toou.Toou.domain.model.TradeType;
+import com.Toou.Toou.exception.CustomException;
+import com.Toou.Toou.exception.CustomExceptionDetail;
+import com.Toou.Toou.port.out.StockOrderPort;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class StockOrderAdapter implements StockOrderPort {
+
+	private final AccountAssetJpaRepository accountAssetJpaRepository;
+	private final HoldingStockJpaRepository holdingStockJpaRepository;
+
+
+	@Override
+	@Transactional
+	public void orderStock(StockOrder stockOrder, AccountAsset accountAsset) {
+		AccountAssetEntity accountAssetEntity = accountAssetJpaRepository.findById(accountAsset.getId())
+				.orElseThrow(() -> new CustomException(
+						CustomExceptionDetail.USER_NOT_FOUND)); //TODO: 이렇게 될리가 없는데 Optional이란 이유로 해야하나..
+
+		if (stockOrder.getTradeType() == TradeType.BUY) {
+			handleBuyOrder(stockOrder, accountAssetEntity);
+		} else if (stockOrder.getTradeType() == TradeType.SELL) {
+			handleSellOrder(stockOrder, accountAssetEntity);
+		}
+	}
+
+
+	private void handleBuyOrder(StockOrder stockOrder, AccountAssetEntity accountAssetEntity) {
+		// 현재 보유한 주식인지 확인
+		HoldingStockEntity holdingStock = holdingStockJpaRepository.findByStockCodeAndAccountAssetId(
+				stockOrder.getStockCode(), accountAssetEntity.getId()).orElse(null);
+		;
+
+		//TODO: buyable 이용해서 구매 가능한지 판단 -> 어댑터 사용?
+
+		// 주문 금액 계산 및 deposit 감소
+		Long totalCost = calculateTotalCost(stockOrder);
+		accountAssetEntity.setDeposit(accountAssetEntity.getDeposit() - totalCost);
+
+		// 보유 주식이 없다면 새로 추가
+		if (holdingStock == null) {
+			holdingStock = new HoldingStockEntity(stockOrder, accountAssetEntity);
+			holdingStockJpaRepository.save(holdingStock);
+		} else {
+			// 이미 보유한 주식이라면 수량과 평균 매입가, 평가 금액 업데이트
+			Long newQuantity = holdingStock.getQuantity() + stockOrder.getOrderQuantity();
+			Long newValuation = holdingStock.getValuation() + totalCost;
+			Long newAveragePurchasePrice = newValuation / newQuantity;
+
+			holdingStock.setQuantity(newQuantity);
+			holdingStock.setAveragePurchasePrice(newAveragePurchasePrice);
+			holdingStock.setValuation(newValuation);
+			holdingStock.setCurrentPrice(stockOrder.getStockPrice());
+			holdingStockJpaRepository.save(holdingStock);
+		}
+	}
+
+	private void handleSellOrder(StockOrder stockOrder, AccountAssetEntity accountAssetEntity) {
+		// 현재 보유한 주식을 가져옴
+		HoldingStockEntity holdingStock = holdingStockJpaRepository.findByStockCodeAndAccountAssetId(
+						stockOrder.getStockCode(), accountAssetEntity.getId()).stream().findFirst()
+				.orElseThrow(() -> new CustomException(CustomExceptionDetail.NO_HOLDING_STOCK));
+
+		// 판매 가능한 수량인지 확인
+		if (holdingStock.getQuantity() < stockOrder.getOrderQuantity()) {
+			throw new CustomException(CustomExceptionDetail.WRONG_SELL_QUANTITY);
+		}
+
+		// 판매 금액 계산 및 deposit 증가
+		Long totalSale = calculateTotalCost(stockOrder);
+		accountAssetEntity.setDeposit(accountAssetEntity.getDeposit() + totalSale);
+
+		// 주식 수량 및 평가 금액 업데이트
+		holdingStock.setQuantity(holdingStock.getQuantity() - stockOrder.getOrderQuantity());
+		holdingStock.setValuation(holdingStock.getValuation() - totalSale);
+		if (holdingStock.getQuantity() == 0) {
+			holdingStockJpaRepository.delete(holdingStock);
+		} else {
+			holdingStockJpaRepository.save(holdingStock);
+		}
+	}
+
+	private Long calculateTotalCost(StockOrder stockOrder) {
+		return stockOrder.getStockPrice() * stockOrder.getOrderQuantity();
+	}
+}

--- a/src/main/java/com/Toou/Toou/exception/CustomExceptionDetail.java
+++ b/src/main/java/com/Toou/Toou/exception/CustomExceptionDetail.java
@@ -7,7 +7,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum CustomExceptionDetail {
 	STOCK_NOT_FOUND("stock_not_found", "해당하는 주식 종목을 찾을 수 없습니다"),
-	USER_NOT_FOUND("user_not_found", "해당하는 id로 사용자를 찾을 수 없습니다");
+	USER_NOT_FOUND("user_not_found", "해당하는 id로 사용자를 찾을 수 없습니다"),
+	WRONG_BUY_ORDER("wrong_buy_order", "유효하지 않은 매수 주문입니다"),
+	NO_HOLDING_STOCK("no_holding_stock", "보유하지 않은 종목입니다"),
+	WRONG_SELL_QUANTITY("wrong_sell_quantity", "매도 가능한 수량이 아닙니다");
 
 	private final String type;
 	private final String message;

--- a/src/main/java/com/Toou/Toou/port/in/AccountController.java
+++ b/src/main/java/com/Toou/Toou/port/in/AccountController.java
@@ -38,8 +38,6 @@ public class AccountController {
 	private final BuyableStockUseCase buyableStockUseCase;
 	private final StockOrderUseCase stockOrderUseCase;
 
-	private static final String DUMMY_STOCK_NAME = "더미종목명";
-
 	@Value("${dummy.newest-date}")
 	@DateTimeFormat(pattern = "yyyy-MM-dd")
 	private LocalDate DUMMY_NEWEST_DATE;
@@ -90,20 +88,20 @@ public class AccountController {
 	}
 
 	@PostMapping("/stocks/{stockCode}/order")
-	ResponseEntity<VoidResponse> buyStock(
+	ResponseEntity<VoidResponse> orderStock(
 			@CookieValue(value = "kakaoId") String kakaoId,
 			@Valid @RequestBody StockOrderRequest request,
 			@PathVariable String stockCode) {
 		AccountAsset accountAsset = getAccountAssetByKakaoId(kakaoId);
 		StockOrder stockOrder = StockOrder.builder()
 				.stockCode(stockCode)
-				.stockName(DUMMY_STOCK_NAME)
+				.stockName(request.getStockName())
 				.stockPrice(request.getStockPrice())
 				.orderQuantity(request.getOrderQuantity())
 				.tradeType(request.getTradeType())
 				.accountAsset(accountAsset)
 				.build();
-		StockOrderUseCase.Input input = new StockOrderUseCase.Input(stockOrder);
+		StockOrderUseCase.Input input = new StockOrderUseCase.Input(stockOrder, accountAsset);
 		StockOrderUseCase.Output output = stockOrderUseCase.execute(input);
 		VoidResponse response = new VoidResponse(true);
 		return ResponseEntity.ok().body(response);

--- a/src/main/java/com/Toou/Toou/port/in/dto/StockOrderRequest.java
+++ b/src/main/java/com/Toou/Toou/port/in/dto/StockOrderRequest.java
@@ -10,6 +10,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class StockOrderRequest {
 
+	@Schema(description = "종목명")
+	@NotNull
+	private String stockName;
+
 	@Schema(description = "주식 가격")
 	@NotNull
 	private Long stockPrice;

--- a/src/main/java/com/Toou/Toou/port/out/StockOrderPort.java
+++ b/src/main/java/com/Toou/Toou/port/out/StockOrderPort.java
@@ -1,0 +1,9 @@
+package com.Toou.Toou.port.out;
+
+import com.Toou.Toou.domain.model.AccountAsset;
+import com.Toou.Toou.domain.model.StockOrder;
+
+public interface StockOrderPort {
+
+	void orderStock(StockOrder stockOrder, AccountAsset accountAsset);
+}

--- a/src/main/java/com/Toou/Toou/usecase/StockOrderService.java
+++ b/src/main/java/com/Toou/Toou/usecase/StockOrderService.java
@@ -1,5 +1,6 @@
 package com.Toou.Toou.usecase;
 
+import com.Toou.Toou.port.out.StockOrderPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -7,8 +8,11 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class StockOrderService implements StockOrderUseCase {
 
+	private final StockOrderPort stockOrderPort;
+
 	@Override
 	public Output execute(Input input) {
+		stockOrderPort.orderStock(input.stockOrder, input.accountAsset);
 		return new Output();
 	}
 }

--- a/src/main/java/com/Toou/Toou/usecase/StockOrderUseCase.java
+++ b/src/main/java/com/Toou/Toou/usecase/StockOrderUseCase.java
@@ -1,5 +1,6 @@
 package com.Toou.Toou.usecase;
 
+import com.Toou.Toou.domain.model.AccountAsset;
 import com.Toou.Toou.domain.model.StockOrder;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -13,6 +14,7 @@ public interface StockOrderUseCase {
 	class Input {
 
 		StockOrder stockOrder;
+		AccountAsset accountAsset;
 	}
 
 	@AllArgsConstructor


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type[#issue number]: 작업 내용 -->
<!-- ex) feat[#133]: canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

 <!-- #이슈번호. 머지되면 이슈가 종료됨-->

## 작업 개요
- 매수, 매도 후 asset, 보유 주식 목록 변화

## 작업 사항
### 매수
보유 주식목록에서 있는지 검사. 있으면 값 변경, 없으면 보유 주식목록에 추가.
매수 후 예수금 변경

### 매도 
보유 주식 목록에 해당 종목이 없을경우 에러 응답.
보유 수량보다 많은 개수를 매도할 경우 에러 응답. 
매도 후 보유 주식목록 변경(수량, 평가금액, ). 전량 매도 시 보유 주식 목록에서 종목 삭제. 아니면 수량만 변경
매도 후 asset의 예수금 변경.

미진행된 부분
- 매수에서 예수금에 따라서 매수 가능한지 체크한것 미적용됨
