### PR TITLE
feat[#46]: 개별 주식 평균매수가 수정

### DIFF
--- a/src/main/java/com/Toou/Toou/adapter/mysql/AccountAssetAdapter.java
+++ b/src/main/java/com/Toou/Toou/adapter/mysql/AccountAssetAdapter.java
@@ -37,7 +37,8 @@ public class AccountAssetAdapter implements AccountAssetPort {
 				entity.getDeposit(),
 				entity.getTotalHoldingsValue(),
 				entity.getTotalHoldingsQuantity(),
-				entity.getInvestmentYield()
+				entity.getInvestmentYield(),
+				entity.getTotalPrincipal()
 		);
 	}
 
@@ -49,7 +50,8 @@ public class AccountAssetAdapter implements AccountAssetPort {
 				accountAsset.getDeposit(),
 				accountAsset.getTotalHoldingsValue(),
 				accountAsset.getTotalHoldingsQuantity(),
-				accountAsset.getInvestmentYield()
+				accountAsset.getInvestmentYield(),
+				accountAsset.getTotalPrincipal()
 		);
 	}
 }

--- a/src/main/java/com/Toou/Toou/adapter/mysql/AccountAssetAdapter.java
+++ b/src/main/java/com/Toou/Toou/adapter/mysql/AccountAssetAdapter.java
@@ -16,8 +16,8 @@ public class AccountAssetAdapter implements AccountAssetPort {
 	private final AccountAssetJpaRepository accountAssetJpaRepository;
 
 	@Override
-	public AccountAsset findAssetByKakaoId(String kakaoId) {
-		AccountAssetEntity entity = accountAssetJpaRepository.findByKakaoId(kakaoId)
+	public AccountAsset findByProviderId(String providerId) {
+		AccountAssetEntity entity = accountAssetJpaRepository.findByProviderId(providerId)
 				.orElseThrow(() -> new CustomException(CustomExceptionDetail.USER_NOT_FOUND));
 		return toDomainModel(entity);
 	}
@@ -32,7 +32,8 @@ public class AccountAssetAdapter implements AccountAssetPort {
 	private AccountAsset toDomainModel(AccountAssetEntity entity) {
 		return new AccountAsset(
 				entity.getId(),
-				entity.getKakaoId(),
+				entity.getOauthProvider(),
+				entity.getProviderId(),
 				entity.getTotalAsset(),
 				entity.getDeposit(),
 				entity.getTotalHoldingsValue(),
@@ -45,7 +46,8 @@ public class AccountAssetAdapter implements AccountAssetPort {
 	private AccountAssetEntity toEntity(AccountAsset accountAsset) {
 		return new AccountAssetEntity(
 				accountAsset.getId(),
-				accountAsset.getKakaoId(),
+				accountAsset.getOauthProvider(),
+				accountAsset.getProviderId(),
 				accountAsset.getTotalAsset(),
 				accountAsset.getDeposit(),
 				accountAsset.getTotalHoldingsValue(),

--- a/src/main/java/com/Toou/Toou/adapter/mysql/AccountAssetJpaRepository.java
+++ b/src/main/java/com/Toou/Toou/adapter/mysql/AccountAssetJpaRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AccountAssetJpaRepository extends JpaRepository<AccountAssetEntity, Long> {
 
-	Optional<AccountAssetEntity> findByKakaoId(String kakaoId);
+	Optional<AccountAssetEntity> findByProviderId(String providerId);
 
 }

--- a/src/main/java/com/Toou/Toou/adapter/mysql/HoldingStockAdapter.java
+++ b/src/main/java/com/Toou/Toou/adapter/mysql/HoldingStockAdapter.java
@@ -49,12 +49,13 @@ public class HoldingStockAdapter implements HoldingStockPort {
 				entity.getId(),
 				entity.getStockCode(),
 				entity.getStockName(),
-				entity.getAveragePurchasePrice(),
+				entity.getAverageBuyPrice(),
 				entity.getCurrentPrice(),
 				entity.getQuantity(),
 				entity.getValuation(),
 				entity.getYield(),
-				entity.getAccountAssetId()
+				entity.getAccountAssetId(),
+				entity.getPrincipal()
 		);
 	}
 
@@ -63,12 +64,13 @@ public class HoldingStockAdapter implements HoldingStockPort {
 				holdingIndividualStock.getId(),
 				holdingIndividualStock.getStockCode(),
 				holdingIndividualStock.getStockName(),
-				holdingIndividualStock.getAveragePurchasePrice(),
+				holdingIndividualStock.getAverageBuyPrice(),
 				holdingIndividualStock.getCurrentPrice(),
 				holdingIndividualStock.getQuantity(),
 				holdingIndividualStock.getValuation(),
 				holdingIndividualStock.getYield(),
-				holdingIndividualStock.getAccountAssetId()
+				holdingIndividualStock.getAccountAssetId(),
+				holdingIndividualStock.getPrincipal()
 		);
 	}
 }

--- a/src/main/java/com/Toou/Toou/adapter/mysql/entity/AccountAssetEntity.java
+++ b/src/main/java/com/Toou/Toou/adapter/mysql/entity/AccountAssetEntity.java
@@ -1,8 +1,11 @@
 package com.Toou.Toou.adapter.mysql.entity;
 
 
+import com.Toou.Toou.domain.model.OAuthProvider;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -20,8 +23,12 @@ public class AccountAssetEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(name = "kakao_id", nullable = false)
-	private String kakaoId;
+	@Enumerated(EnumType.STRING)
+	@Column(name = "oauth_provider", nullable = false)
+	private OAuthProvider oauthProvider;
+
+	@Column(name = "provider_id", nullable = false)
+	private String providerId;
 
 	@Column(name = "total_asset", nullable = false)
 	private Long totalAsset;

--- a/src/main/java/com/Toou/Toou/adapter/mysql/entity/AccountAssetEntity.java
+++ b/src/main/java/com/Toou/Toou/adapter/mysql/entity/AccountAssetEntity.java
@@ -37,4 +37,8 @@ public class AccountAssetEntity {
 
 	@Column(name = "investment_yield", nullable = false)
 	private Double investmentYield;
+
+	@Column(name = "total_principal", nullable = false)
+	private Long totalPrincipal;
+
 }

--- a/src/main/java/com/Toou/Toou/adapter/mysql/entity/HoldingStockEntity.java
+++ b/src/main/java/com/Toou/Toou/adapter/mysql/entity/HoldingStockEntity.java
@@ -26,8 +26,8 @@ public class HoldingStockEntity {
 	@Column(name = "stock_name", nullable = false)
 	private String stockName;
 
-	@Column(name = "average_purchase_price", nullable = false)
-	private Long averagePurchasePrice;
+	@Column(name = "average_buy_price", nullable = false)
+	private Long averageBuyPrice;
 
 	@Column(name = "current_price", nullable = false)
 	private Long currentPrice;
@@ -40,6 +40,9 @@ public class HoldingStockEntity {
 
 	@Column(name = "yield", nullable = false)
 	private Double yield;
+
+	@Column(name = "principal", nullable = false)
+	private Long principal;
 
 	@Column(name = "account_asset_id", nullable = false)
 	private Long accountAssetId;

--- a/src/main/java/com/Toou/Toou/domain/model/AccountAsset.java
+++ b/src/main/java/com/Toou/Toou/domain/model/AccountAsset.java
@@ -18,38 +18,56 @@ public class AccountAsset {
 	private Long totalHoldingsValue;
 	private Long totalHoldingsQuantity;
 	private Double investmentYield;
+	private Long totalPrincipal;
 
-	public AccountAsset updateWhenBuyStock(Long totalPrice, boolean isFirstBuy) {
+	public AccountAsset updateWhenBuyStock(StockOrder stockOrder, boolean isFirstBuy) {
+		Long totalOrderValue = stockOrder.getStockPrice() * stockOrder.getOrderQuantity();
+		Long newDeposit = this.deposit - totalOrderValue;
+		Long newTotalHoldingsValue = this.totalHoldingsValue + totalOrderValue;
+		Long newTotalHoldingsQuantity = isFirstBuy
+				? this.totalHoldingsQuantity + 1
+				: this.totalHoldingsQuantity;
+		Long newPrincipal = this.totalPrincipal + newTotalHoldingsValue;
+
 		return new AccountAsset(
 				this.id,
 				this.kakaoId,
 				this.totalAsset,
-				this.deposit - totalPrice,
-				this.totalHoldingsValue + totalPrice,
-				isFirstBuy ? this.totalHoldingsQuantity + 1 : this.totalHoldingsQuantity,
-				this.investmentYield
+				newDeposit,
+				newTotalHoldingsValue,
+				newTotalHoldingsQuantity,
+				this.investmentYield,
+				newPrincipal
 		);
 	}
 
 
-	public AccountAsset updateWhenSellStock(Long totalPrice, boolean isLastStockSold) {
+	public AccountAsset updateWhenSellStock(StockOrder stockOrder, boolean isLastStockSold) {
+		Long totalOrderValue = stockOrder.getStockPrice() * stockOrder.getOrderQuantity();
+		Long newDeposit = this.deposit + totalOrderValue;
+		Long newTotalHoldingsValue = this.totalHoldingsValue - totalOrderValue;
+		Long newTotalHoldingsQuantity = isLastStockSold
+				? this.totalHoldingsQuantity - 1
+				: this.totalHoldingsQuantity;
+		Long newPrincipal = this.totalPrincipal - newTotalHoldingsValue;
+
 		return new AccountAsset(
 				this.id,
 				this.kakaoId,
 				this.totalAsset,
-				this.deposit + totalPrice,
-				this.totalHoldingsValue - totalPrice,
-				isLastStockSold ? this.totalHoldingsQuantity - 1 : this.totalHoldingsQuantity,
-				this.investmentYield
+				newDeposit,
+				newTotalHoldingsValue,
+				newTotalHoldingsQuantity,
+				this.investmentYield,
+				newPrincipal
 		);
 	}
 
-	public AccountAsset updateWithNewHoldingsData(Long totalHoldingsValue,
-			Long totalInitialInvestment) {
+	public AccountAsset updateWithNewHoldingsData(Long totalHoldingsValue) {
 		long newTotalAsset = this.deposit + totalHoldingsValue;
-		long initialTotalAsset = this.deposit + totalInitialInvestment;
 		double newInvestmentYield =
-				((double) (newTotalAsset - initialTotalAsset) / initialTotalAsset) * 100;
+				((double) (newTotalAsset - this.totalPrincipal) / this.totalPrincipal) * 100;
+
 		return new AccountAsset(
 				this.id,
 				this.kakaoId,
@@ -57,7 +75,8 @@ public class AccountAsset {
 				this.deposit,
 				totalHoldingsValue,
 				this.totalHoldingsQuantity,
-				newInvestmentYield
+				newInvestmentYield,
+				this.totalPrincipal
 		);
 	}
 

--- a/src/main/java/com/Toou/Toou/domain/model/AccountAsset.java
+++ b/src/main/java/com/Toou/Toou/domain/model/AccountAsset.java
@@ -4,12 +4,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
-@Setter
 @Builder
 public class AccountAsset {
 
@@ -20,4 +18,47 @@ public class AccountAsset {
 	private Long totalHoldingsValue;
 	private Long totalHoldingsQuantity;
 	private Double investmentYield;
+
+	public AccountAsset updateWhenBuyStock(Long totalPrice, boolean isFirstBuy) {
+		return new AccountAsset(
+				this.id,
+				this.kakaoId,
+				this.totalAsset,
+				this.deposit - totalPrice,
+				this.totalHoldingsValue + totalPrice,
+				isFirstBuy ? this.totalHoldingsQuantity + 1 : this.totalHoldingsQuantity,
+				this.investmentYield
+		);
+	}
+
+
+	public AccountAsset updateWhenSellStock(Long totalPrice, boolean isLastStockSold) {
+		return new AccountAsset(
+				this.id,
+				this.kakaoId,
+				this.totalAsset,
+				this.deposit + totalPrice,
+				this.totalHoldingsValue - totalPrice,
+				isLastStockSold ? this.totalHoldingsQuantity - 1 : this.totalHoldingsQuantity,
+				this.investmentYield
+		);
+	}
+
+	public AccountAsset updateWithNewHoldingsData(Long totalHoldingsValue,
+			Long totalInitialInvestment) {
+		long newTotalAsset = this.deposit + totalHoldingsValue;
+		long initialTotalAsset = this.deposit + totalInitialInvestment;
+		double newInvestmentYield =
+				((double) (newTotalAsset - initialTotalAsset) / initialTotalAsset) * 100;
+		return new AccountAsset(
+				this.id,
+				this.kakaoId,
+				newTotalAsset,
+				this.deposit,
+				totalHoldingsValue,
+				this.totalHoldingsQuantity,
+				newInvestmentYield
+		);
+	}
+
 }

--- a/src/main/java/com/Toou/Toou/domain/model/AccountAsset.java
+++ b/src/main/java/com/Toou/Toou/domain/model/AccountAsset.java
@@ -12,7 +12,8 @@ import lombok.NoArgsConstructor;
 public class AccountAsset {
 
 	private Long id;
-	private String kakaoId;
+	private OAuthProvider oauthProvider; // OAuth 제공자 타입
+	private String providerId; // OAuth 제공자에서의 유저 ID
 	private Long totalAsset;
 	private Long deposit;
 	private Long totalHoldingsValue;
@@ -31,7 +32,8 @@ public class AccountAsset {
 
 		return new AccountAsset(
 				this.id,
-				this.kakaoId,
+				this.oauthProvider,
+				this.providerId,
 				this.totalAsset,
 				newDeposit,
 				newTotalHoldingsValue,
@@ -53,7 +55,8 @@ public class AccountAsset {
 
 		return new AccountAsset(
 				this.id,
-				this.kakaoId,
+				this.oauthProvider,
+				this.providerId,
 				this.totalAsset,
 				newDeposit,
 				newTotalHoldingsValue,
@@ -70,7 +73,8 @@ public class AccountAsset {
 
 		return new AccountAsset(
 				this.id,
-				this.kakaoId,
+				this.oauthProvider,
+				this.providerId,
 				newTotalAsset,
 				this.deposit,
 				totalHoldingsValue,

--- a/src/main/java/com/Toou/Toou/domain/model/HoldingIndividualStock.java
+++ b/src/main/java/com/Toou/Toou/domain/model/HoldingIndividualStock.java
@@ -12,21 +12,86 @@ public class HoldingIndividualStock {
 	private Long id;
 	private String stockCode;              // 종목 코드
 	private String stockName;              // 종목명
-	private Long averagePurchasePrice;     // 평균 매수가
+	private Long averageBuyPrice;     // 평균 매수가
 	private Long currentPrice;             // 현재 가격
 	private Long quantity;                 // 보유 주식수
 	private Long valuation;                // 평가금액
 	private Double yield;
 	private Long accountAssetId;
+	private Long principal;                 //투자 원금
 
 	public HoldingIndividualStock(StockOrder stockOrder, long accountAssetId) {
 		this.stockCode = stockOrder.getStockCode();
 		this.stockName = stockOrder.getStockName();
-		this.averagePurchasePrice = stockOrder.getStockPrice();
+		this.averageBuyPrice = stockOrder.getStockPrice();
 		this.currentPrice = stockOrder.getStockPrice();
 		this.quantity = stockOrder.getOrderQuantity();
 		this.valuation = stockOrder.getStockPrice() * stockOrder.getOrderQuantity();
 		this.yield = 0.0; // 초기 수익률은 0으로 설정
 		this.accountAssetId = accountAssetId;
+		this.principal = stockOrder.getStockPrice() * stockOrder.getOrderQuantity();
+	}
+
+	public HoldingIndividualStock updateWhenBuyStock(StockOrder stockOrder) {
+		long totalOrderValue = stockOrder.getStockPrice() * stockOrder.getOrderQuantity();
+		Long newQuantity = this.quantity + stockOrder.getOrderQuantity();
+		Long newValuation = this.valuation + totalOrderValue;
+		Long newPrincipal = this.principal + totalOrderValue;
+		Long newAverageBuyPrice = newPrincipal / newQuantity;
+		Double newYield =
+				((double) (this.currentPrice - newAverageBuyPrice) / newAverageBuyPrice) * 100;
+		return new HoldingIndividualStock(
+				this.id,
+				this.stockCode,
+				this.stockName,
+				newAverageBuyPrice,
+				this.currentPrice,
+				newQuantity,
+				newValuation,
+				newYield,
+				this.accountAssetId,
+				newPrincipal
+		);
+	}
+
+	public HoldingIndividualStock updateWhenSellStock(StockOrder stockOrder) {
+		long totalOrderValue = stockOrder.getStockPrice() * stockOrder.getOrderQuantity();
+		Long newQuantity = this.quantity - stockOrder.getOrderQuantity();
+		Long newValuation = this.valuation - totalOrderValue;
+		Long newPrincipal = this.principal - totalOrderValue;
+		Long newAverageBuyPrice = newPrincipal / newQuantity;
+		Double newYield =
+				((double) (this.currentPrice - newAverageBuyPrice) / newAverageBuyPrice) * 100;
+		return new HoldingIndividualStock(
+				this.id,
+				this.stockCode,
+				this.stockName,
+				newAverageBuyPrice,
+				this.currentPrice,
+				newQuantity,
+				newValuation,
+				newYield,
+				this.accountAssetId,
+				newPrincipal
+		);
+	}
+
+	public HoldingIndividualStock updateWithNewHoldingsData(Long newPrice) {
+		Long newValuation = newPrice * this.quantity;
+		Double newYield =
+				((double) (this.currentPrice - this.averageBuyPrice) / this.averageBuyPrice) * 100;
+
+		return new HoldingIndividualStock(
+				this.id,
+				this.stockCode,
+				this.stockName,
+				this.averageBuyPrice,
+				newPrice,
+				this.quantity,
+				newValuation,
+				newYield,
+				this.accountAssetId,
+				this.principal
+		);
 	}
 }

--- a/src/main/java/com/Toou/Toou/domain/model/OAuthProvider.java
+++ b/src/main/java/com/Toou/Toou/domain/model/OAuthProvider.java
@@ -1,0 +1,6 @@
+package com.Toou.Toou.domain.model;
+
+public enum OAuthProvider {
+	KAKAO,
+	GOOGLE
+}

--- a/src/main/java/com/Toou/Toou/port/in/dto/HoldingIndividualDto.java
+++ b/src/main/java/com/Toou/Toou/port/in/dto/HoldingIndividualDto.java
@@ -30,7 +30,7 @@ public class HoldingIndividualDto {
 	public static HoldingIndividualDto fromDomainModel(HoldingIndividualStock domainModel) {
 		return new HoldingIndividualDto(
 				domainModel.getStockName(),
-				domainModel.getAveragePurchasePrice(),
+				domainModel.getAverageBuyPrice(),
 				domainModel.getCurrentPrice(),
 				domainModel.getQuantity(),
 				domainModel.getValuation(),

--- a/src/main/java/com/Toou/Toou/port/out/AccountAssetPort.java
+++ b/src/main/java/com/Toou/Toou/port/out/AccountAssetPort.java
@@ -4,7 +4,7 @@ import com.Toou.Toou.domain.model.AccountAsset;
 
 public interface AccountAssetPort {
 
-	AccountAsset findAssetByKakaoId(String kakaoId);
+	AccountAsset findByProviderId(String providerId);
 
 	AccountAsset saveAsset(AccountAsset accountAsset);
 }

--- a/src/main/java/com/Toou/Toou/usecase/AccountAssetService.java
+++ b/src/main/java/com/Toou/Toou/usecase/AccountAssetService.java
@@ -15,7 +15,7 @@ public class AccountAssetService implements AccountAssetUseCase {
 	@Transactional
 	@Override
 	public Output execute(AccountAssetUseCase.Input input) {
-		AccountAsset accountAsset = accountAssetPort.findAssetByKakaoId(input.kakaoId);
+		AccountAsset accountAsset = accountAssetPort.findByProviderId(input.providerId);
 		return new Output(accountAsset);
 	}
 }

--- a/src/main/java/com/Toou/Toou/usecase/AccountAssetUseCase.java
+++ b/src/main/java/com/Toou/Toou/usecase/AccountAssetUseCase.java
@@ -12,7 +12,7 @@ public interface AccountAssetUseCase {
 	@Data
 	class Input {
 
-		String kakaoId;
+		String providerId;
 	}
 
 	@AllArgsConstructor

--- a/src/main/java/com/Toou/Toou/usecase/AccountHoldingService.java
+++ b/src/main/java/com/Toou/Toou/usecase/AccountHoldingService.java
@@ -30,7 +30,6 @@ public class AccountHoldingService implements AccountHoldingUseCase {
 				accountAsset.getId());
 
 		Long totalHoldingsValue = 0L;
-		Long totalInitialInvestment = 0L;  // 주식들 평균 매수금액 * 보유 수량의 합
 
 		for (HoldingIndividualStock holding : holdings) {
 			StockMetadata stockMetadata = stockMetadataPort.findStockByStockCode(holding.getStockCode());
@@ -41,8 +40,7 @@ public class AccountHoldingService implements AccountHoldingUseCase {
 					stockDailyHistory.getClosingPrice());
 			holdingStockPort.save(newHolding);
 		}
-		AccountAsset updatedAccountAsset = accountAsset.updateWithNewHoldingsData(totalHoldingsValue,
-				totalInitialInvestment);
+		AccountAsset updatedAccountAsset = accountAsset.updateWithNewHoldingsData(totalHoldingsValue);
 		AccountAsset savedAccountAsset = accountAssetPort.saveAsset(updatedAccountAsset);
 		return new Output(holdings);
 	}

--- a/src/main/java/com/Toou/Toou/usecase/AccountHoldingService.java
+++ b/src/main/java/com/Toou/Toou/usecase/AccountHoldingService.java
@@ -25,7 +25,7 @@ public class AccountHoldingService implements AccountHoldingUseCase {
 	@Transactional
 	@Override
 	public Output execute(AccountHoldingUseCase.Input input) {
-		AccountAsset accountAsset = accountAssetPort.findAssetByKakaoId(input.kakaoId);
+		AccountAsset accountAsset = accountAssetPort.findByProviderId(input.providerId);
 		List<HoldingIndividualStock> holdings = holdingStockPort.findAllHoldingsByAccountAssetId(
 				accountAsset.getId());
 

--- a/src/main/java/com/Toou/Toou/usecase/AccountHoldingService.java
+++ b/src/main/java/com/Toou/Toou/usecase/AccountHoldingService.java
@@ -63,19 +63,9 @@ public class AccountHoldingService implements AccountHoldingUseCase {
 			);
 			holdingStockPort.save(newHolding);
 		}
-
-		// 현재 총 자산 = 예수금 + 주식들 평가금액 * 보유 수량의 합
-		Long currentTotalAsset = accountAsset.getDeposit() + totalHoldingsValue;
-
-		// 초기 총 자산 = 예수금 + 주식들 평균 매수금액 * 보유 수량의 합
-		Long initialTotalAsset = accountAsset.getDeposit() + totalInitialInvestment;
-		double totalInvestmentYield =
-				((double) (currentTotalAsset - initialTotalAsset) / initialTotalAsset) * 100;
-		accountAsset.setInvestmentYield(totalInvestmentYield);
-
-		accountAsset.setTotalHoldingsValue(totalHoldingsValue);
-		accountAsset.setTotalAsset(accountAsset.getDeposit() + accountAsset.getTotalHoldingsValue());
-		AccountAsset savedAccountAsset = accountAssetPort.saveAsset(accountAsset);
+		AccountAsset updatedAccountAsset = accountAsset.updateWithNewHoldingsData(totalHoldingsValue,
+				totalInitialInvestment);
+		AccountAsset savedAccountAsset = accountAssetPort.saveAsset(updatedAccountAsset);
 		return new Output(holdings);
 	}
 }

--- a/src/main/java/com/Toou/Toou/usecase/AccountHoldingService.java
+++ b/src/main/java/com/Toou/Toou/usecase/AccountHoldingService.java
@@ -35,32 +35,10 @@ public class AccountHoldingService implements AccountHoldingUseCase {
 		for (HoldingIndividualStock holding : holdings) {
 			StockMetadata stockMetadata = stockMetadataPort.findStockByStockCode(holding.getStockCode());
 			StockDailyHistory stockDailyHistory = stockHistoryPort.findStockHistoryByDate(
-					stockMetadata.getId(), input.todayDate);
-
-			Long newCurrentPrice = stockDailyHistory.getClosingPrice();
-
-			// 평가 금액 = 현재 가격 * 보유 주식 수
-			Long newValuation = newCurrentPrice * holding.getQuantity();
-			totalHoldingsValue += newValuation;
-
-			Long initialInvestment = holding.getAveragePurchasePrice() * holding.getQuantity();
-			totalInitialInvestment += initialInvestment;
-
-			// 수익률 = ((현재 가격 - 평균 매수가) / 평균 매수가) * 100
-			Double newYield = ((double) (newCurrentPrice - holding.getAveragePurchasePrice())
-					/ holding.getAveragePurchasePrice()) * 100;
-
-			HoldingIndividualStock newHolding = new HoldingIndividualStock(
-					holding.getId(),
-					holding.getStockCode(),
-					holding.getStockName(),
-					holding.getAveragePurchasePrice(),
-					newCurrentPrice,
-					holding.getQuantity(),
-					newValuation,
-					newYield,
-					holding.getAccountAssetId()
-			);
+					stockMetadata.getId(),
+					input.todayDate); //TODO: DB에 저장한 값이 최신 값이 아닐 경우, open api로 값을 저장해야함
+			HoldingIndividualStock newHolding = holding.updateWithNewHoldingsData(
+					stockDailyHistory.getClosingPrice());
 			holdingStockPort.save(newHolding);
 		}
 		AccountAsset updatedAccountAsset = accountAsset.updateWithNewHoldingsData(totalHoldingsValue,

--- a/src/main/java/com/Toou/Toou/usecase/AccountHoldingUseCase.java
+++ b/src/main/java/com/Toou/Toou/usecase/AccountHoldingUseCase.java
@@ -14,7 +14,7 @@ public interface AccountHoldingUseCase {
 	@Data
 	class Input {
 
-		String kakaoId;
+		String providerId;
 		LocalDate todayDate;
 	}
 

--- a/src/main/java/com/Toou/Toou/usecase/BuyableStockService.java
+++ b/src/main/java/com/Toou/Toou/usecase/BuyableStockService.java
@@ -20,7 +20,7 @@ public class BuyableStockService implements BuyableStockUseCase {
 
 	@Override
 	public Output execute(Input input) {
-		AccountAsset accountAsset = accountAssetPort.findAssetByKakaoId(input.kakaoId);
+		AccountAsset accountAsset = accountAssetPort.findByProviderId(input.providerId);
 		StockMetadata stockMetadata = stockMetadataPort.findStockByStockCode(input.stockCode);
 		StockDailyHistory stockDailyHistory = stockHistoryPort.findStockHistoryByDate(
 				stockMetadata.getId(), input.buyDate);

--- a/src/main/java/com/Toou/Toou/usecase/BuyableStockUseCase.java
+++ b/src/main/java/com/Toou/Toou/usecase/BuyableStockUseCase.java
@@ -15,7 +15,7 @@ public interface BuyableStockUseCase {
 
 		String stockCode;
 		LocalDate buyDate;
-		String kakaoId;
+		String providerId;
 	}
 
 	@AllArgsConstructor

--- a/src/main/java/com/Toou/Toou/usecase/SellableStockService.java
+++ b/src/main/java/com/Toou/Toou/usecase/SellableStockService.java
@@ -20,7 +20,7 @@ public class SellableStockService implements SellableStockUseCase {
 
 	@Override
 	public Output execute(Input input) {
-		AccountAsset accountAsset = accountAssetPort.findAssetByKakaoId(input.kakaoId);
+		AccountAsset accountAsset = accountAssetPort.findByProviderId(input.providerId);
 		HoldingIndividualStock holdingIndividualStock = holdingStockPort.findHoldingByStockCodeAndAssetId(
 				input.stockCode, accountAsset.getId());
 		StockMetadata stockMetadata = stockMetadataPort.findStockByStockCode(input.stockCode);

--- a/src/main/java/com/Toou/Toou/usecase/SellableStockUseCase.java
+++ b/src/main/java/com/Toou/Toou/usecase/SellableStockUseCase.java
@@ -13,7 +13,7 @@ public interface SellableStockUseCase {
 	class Input {
 
 		String stockCode;
-		String kakaoId;
+		String providerId;
 	}
 
 	@AllArgsConstructor

--- a/src/main/java/com/Toou/Toou/usecase/StockOrderService.java
+++ b/src/main/java/com/Toou/Toou/usecase/StockOrderService.java
@@ -63,9 +63,7 @@ public class StockOrderService implements StockOrderUseCase {
 				? new HoldingIndividualStock(stockOrder, accountAsset.getId())
 				: holdingIndividualStock.updateWhenBuyStock(stockOrder);
 
-		Long totalPrice = calculateTotalPrice(stockOrder);
-		AccountAsset updatedAccountAsset = accountAsset.updateWhenBuyStock(totalPrice, isFirstBuy);
-
+		AccountAsset updatedAccountAsset = accountAsset.updateWhenBuyStock(stockOrder, isFirstBuy);
 		HoldingIndividualStock savedHoldingIndividualStock = holdingStockPort.save(
 				updatedHoldingIndividualStock);
 		accountAssetPort.saveAsset(updatedAccountAsset);
@@ -86,8 +84,7 @@ public class StockOrderService implements StockOrderUseCase {
 				? null
 				: holdingIndividualStock.updateWhenSellStock(stockOrder);
 
-		Long totalPrice = calculateTotalPrice(stockOrder);
-		AccountAsset updatedAccountAsset = accountAsset.updateWhenSellStock(totalPrice,
+		AccountAsset updatedAccountAsset = accountAsset.updateWhenSellStock(stockOrder,
 				isLastStockSold);
 
 		if (isLastStockSold) {
@@ -96,10 +93,6 @@ public class StockOrderService implements StockOrderUseCase {
 			holdingStockPort.save(updatedHoldingIndividualStock);
 		}
 		AccountAsset savedAccountAsset = accountAssetPort.saveAsset(updatedAccountAsset);
-	}
-
-	private Long calculateTotalPrice(StockOrder stockOrder) {
-		return stockOrder.getStockPrice() * stockOrder.getOrderQuantity();
 	}
 
 	private void validateBuy(AccountAsset accountAsset, StockOrder stockOrder, LocalDate orderDate) {

--- a/src/main/java/com/Toou/Toou/usecase/StockOrderService.java
+++ b/src/main/java/com/Toou/Toou/usecase/StockOrderService.java
@@ -62,9 +62,8 @@ public class StockOrderService implements StockOrderUseCase {
 				holdingIndividualStock, accountAsset);
 
 		Long totalPrice = calculateTotalPrice(stockOrder);
-		boolean isStockEmpty = holdingIndividualStock == null;
-		AccountAsset updatedAccountAsset = updateAsset(totalPrice, accountAsset,
-				stockOrder.getTradeType(), isStockEmpty);
+		boolean isFirstBuy = holdingIndividualStock == null;
+		AccountAsset updatedAccountAsset = accountAsset.updateWhenBuyStock(totalPrice, isFirstBuy);
 
 		HoldingIndividualStock savedHoldingIndividualStock = holdingStockPort.save(
 				updatedHoldingIndividualStock);
@@ -85,9 +84,9 @@ public class StockOrderService implements StockOrderUseCase {
 				holdingIndividualStock, accountAsset);
 
 		Long totalPrice = calculateTotalPrice(stockOrder);
-		boolean isStockEmpty = false;
-		AccountAsset updatedAccountAsset = updateAsset(totalPrice, accountAsset,
-				stockOrder.getTradeType(), isStockEmpty);
+		boolean isLastStockSold = updatedHoldingIndividualStock == null;
+		AccountAsset updatedAccountAsset = accountAsset.updateWhenSellStock(totalPrice,
+				isLastStockSold);
 
 		if (updatedHoldingIndividualStock != null) {
 			holdingStockPort.save(updatedHoldingIndividualStock);
@@ -138,30 +137,6 @@ public class StockOrderService implements StockOrderUseCase {
 				newYield,
 				holdingIndividualStock.getAccountAssetId()
 		);
-	}
-
-	private AccountAsset updateAsset(Long totalPrice, AccountAsset accountAsset,
-			TradeType tradeType, boolean isStockEmpty) {
-		// 총 자산, 투자 수익률 변화 x
-		// 예수금 변화
-		// 총 투자금 변화
-		// 총 종목수 변화
-		if (tradeType == TradeType.BUY) {
-			accountAsset.setDeposit(accountAsset.getDeposit() - totalPrice);
-			accountAsset.setTotalHoldingsValue(accountAsset.getTotalHoldingsValue() + totalPrice);
-
-			if (isStockEmpty) {
-				accountAsset.setTotalHoldingsQuantity(accountAsset.getTotalHoldingsQuantity() + 1);
-			}
-			return accountAsset;
-		}
-		accountAsset.setDeposit(accountAsset.getDeposit() + totalPrice);
-		accountAsset.setTotalHoldingsValue(accountAsset.getTotalHoldingsValue() - totalPrice);
-
-		if (isStockEmpty) {
-			accountAsset.setTotalHoldingsQuantity(accountAsset.getTotalHoldingsQuantity() + 1);
-		}
-		return accountAsset;
 	}
 
 	private Long calculateTotalPrice(StockOrder stockOrder) {

--- a/src/main/java/com/Toou/Toou/usecase/StockOrderService.java
+++ b/src/main/java/com/Toou/Toou/usecase/StockOrderService.java
@@ -30,7 +30,7 @@ public class StockOrderService implements StockOrderUseCase {
 
 	@Override
 	public Output execute(Input input) {
-		AccountAsset accountAsset = accountAssetPort.findAssetByKakaoId(input.kakaoId);
+		AccountAsset accountAsset = accountAssetPort.findByProviderId(input.providerId);
 		StockMetadata stockMetadata = stockMetadataPort.findStockByStockCode(input.stockCode);
 		if (stockMetadata == null) {
 			throw new CustomException(CustomExceptionDetail.STOCK_NOT_FOUND);
@@ -96,7 +96,7 @@ public class StockOrderService implements StockOrderUseCase {
 	}
 
 	private void validateBuy(AccountAsset accountAsset, StockOrder stockOrder, LocalDate orderDate) {
-		StockBuyable stockBuyable = getStockBuyable(accountAsset.getKakaoId(),
+		StockBuyable stockBuyable = getStockBuyable(accountAsset.getProviderId(),
 				stockOrder.getStockCode(), orderDate);
 
 		if (stockBuyable.getBuyableQuantity() < stockOrder.getOrderQuantity()) {
@@ -106,7 +106,7 @@ public class StockOrderService implements StockOrderUseCase {
 	}
 
 	private void validateSell(AccountAsset accountAsset, StockOrder stockOrder, LocalDate orderDate) {
-		StockSellable stockSellable = getStockSellable(accountAsset.getKakaoId(),
+		StockSellable stockSellable = getStockSellable(accountAsset.getProviderId(),
 				stockOrder.getStockCode(), orderDate);
 
 		if (stockOrder.getOrderQuantity() > stockSellable.getSellableQuantity()) {
@@ -115,8 +115,8 @@ public class StockOrderService implements StockOrderUseCase {
 
 	}
 
-	private StockBuyable getStockBuyable(String kakaoId, String stockCode, LocalDate buyDate) {
-		AccountAsset accountAsset = accountAssetPort.findAssetByKakaoId(kakaoId);
+	private StockBuyable getStockBuyable(String providerId, String stockCode, LocalDate buyDate) {
+		AccountAsset accountAsset = accountAssetPort.findByProviderId(providerId);
 		StockMetadata stockMetadata = stockMetadataPort.findStockByStockCode(stockCode);
 		StockDailyHistory stockDailyHistory = stockHistoryPort.findStockHistoryByDate(
 				stockMetadata.getId(), buyDate);
@@ -128,8 +128,8 @@ public class StockOrderService implements StockOrderUseCase {
 				buyableQuantity);
 	}
 
-	private StockSellable getStockSellable(String kakaoId, String stockCode, LocalDate buyDate) {
-		AccountAsset accountAsset = accountAssetPort.findAssetByKakaoId(kakaoId);
+	private StockSellable getStockSellable(String providerId, String stockCode, LocalDate buyDate) {
+		AccountAsset accountAsset = accountAssetPort.findByProviderId(providerId);
 		HoldingIndividualStock holdingIndividualStock = holdingStockPort.findHoldingByStockCodeAndAssetId(
 				stockCode, accountAsset.getId());
 		StockMetadata stockMetadata = stockMetadataPort.findStockByStockCode(stockCode);

--- a/src/main/java/com/Toou/Toou/usecase/StockOrderUseCase.java
+++ b/src/main/java/com/Toou/Toou/usecase/StockOrderUseCase.java
@@ -15,7 +15,7 @@ public interface StockOrderUseCase {
 
 		String stockCode;
 		LocalDate orderDate;
-		String kakaoId;
+		String providerId;
 		TradeType tradeType;
 		Long orderQuantity;
 	}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -31,9 +31,9 @@ VALUES (1, 10000, 11000, 9000, 10500, '2023-08-01'),  -- AJ네트웍스
 
 -- 초기 Account Asset 데이터
 INSERT INTO account_asset (kakao_id, total_asset, deposit, total_holdings_value,
-                           total_holdings_quantity, investment_yield)
-VALUES ('kakao123', 500000, 500000, 0, 0, 0),
-       ('kakao456', 500000, 500000, 0, 0, 0);
+                           total_holdings_quantity, investment_yield, total_principal)
+VALUES ('kakao123', 500000, 500000, 0, 0, 0, 0),
+       ('kakao456', 500000, 500000, 0, 0, 0, 0);
 
 -- 초기 Holding Individual Stock 데이터
 -- INSERT INTO holding_individual_stock (stock_code, stock_name, average_purchase_price, current_price,

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -30,10 +30,10 @@ VALUES (1, 10000, 11000, 9000, 10500, '2023-08-01'),  -- AJ네트웍스
 -- BGF
 
 -- 초기 Account Asset 데이터
-INSERT INTO account_asset (kakao_id, total_asset, deposit, total_holdings_value,
+INSERT INTO account_asset (oauth_provider, provider_id, total_asset, deposit, total_holdings_value,
                            total_holdings_quantity, investment_yield, total_principal)
-VALUES ('kakao123', 500000, 500000, 0, 0, 0, 0),
-       ('kakao456', 500000, 500000, 0, 0, 0, 0);
+VALUES ('KAKAO', 'kakao123', 500000, 500000, 0, 0, 0, 0),
+       ('KAKAO', 'kakao456', 500000, 500000, 0, 0, 0, 0);
 
 -- 초기 Holding Individual Stock 데이터
 -- INSERT INTO holding_individual_stock (stock_code, stock_name, average_purchase_price, current_price,


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type[#issue number]: 작업 내용 -->
<!-- ex) feat[#133]: canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

resolved: #46 <!-- #이슈번호. 머지되면 이슈가 종료됨-->

## 작업 개요
- 모든 도메인 모델의 setter 삭제
- OAuth 엔티티 수정

## 작업 사항
**주문 오류 원인 1) setter 삭제, 도메인 모델에 메서드 추가**
에러가 발생했던 부분이 서비스 안에서 하드코딩 되어있어서, 매수할때 로직을 매도에서 빠졌던 것을 확인했어요. setter를 사용하니, 업데이트되지 않은 필드를 알아보기 힘들어서 삭제했어요. 

또한 필드가 앞으로 바뀔때마다 사용하는 서비스 함수를 모두 수정할 것을 우려해, 도메인 모델에 변경에 필요한 값을 전달하면 새로운 객체를 돌려받도록 했어요.


**주문 오류 원인 2) 투자 원금 필드 추가**
투자 원금 필드로 수익성을 계산하기 더 편리하고, 원금 자체를 보존할 필요가 있어서 추가했어요.

## 고민한 점들
- OAuth 타입을 저장할때 저장공간을 생각해서 1,2,3 같이 숫자로 저장할까 하다가, 나중에 Oauth 타입이 추가될때 순서가 변경되면 다 틀어지기 때문에 문자열 그대로 저장했어요.
