### PR TITLE
refactor[#54]: 비즈니스 로직 도메인으로 이동, 도메인 테스트 작성.

### DIFF
--- a/src/main/java/com/Toou/Toou/adapter/openapi/StockOpenApiAdapter.java
+++ b/src/main/java/com/Toou/Toou/adapter/openapi/StockOpenApiAdapter.java
@@ -17,10 +17,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
-@Repository
+@Component //순수 조회 기능만 있어서 @Repository 사용 안함
 @RequiredArgsConstructor
 public class StockOpenApiAdapter implements StockOpenApiPort {
 

--- a/src/main/java/com/Toou/Toou/domain/model/StockBuyable.java
+++ b/src/main/java/com/Toou/Toou/domain/model/StockBuyable.java
@@ -14,4 +14,10 @@ public class StockBuyable {
 	private Long stockPrice;
 	private Long deposit;
 	private Long buyableQuantity;
+
+	public static StockBuyable of(String stockCode, String stockName, Long closingPrice,
+			Long deposit) {
+		Long buyableQuantity = deposit / closingPrice;
+		return new StockBuyable(stockCode, stockName, closingPrice, deposit, buyableQuantity);
+	}
 }

--- a/src/main/java/com/Toou/Toou/domain/model/StockOrder.java
+++ b/src/main/java/com/Toou/Toou/domain/model/StockOrder.java
@@ -14,46 +14,46 @@ import lombok.NoArgsConstructor;
 @Builder
 public class StockOrder {
 
-  private String stockCode;
-  private String stockName;
-  private Long stockPrice;
-  private Long orderQuantity;
-  private TradeType tradeType;
-  private AccountAsset accountAsset;
+	private String stockCode;
+	private String stockName;
+	private Long stockPrice;
+	private Long orderQuantity;
+	private TradeType tradeType;
+	private AccountAsset accountAsset;
 
 
-  public StockTransactionResultDto handleBuy(AccountAsset accountAsset,
-      HoldingIndividualStock holdingIndividualStock) {
-    validateBuy(accountAsset.getDeposit());
-    boolean isFirstBuy = holdingIndividualStock == null;
-    HoldingIndividualStock updatedHolding = isFirstBuy
-        ? new HoldingIndividualStock(this, accountAsset.getId())
-        : holdingIndividualStock.updateWhenBuyStock(this);
-    AccountAsset updatedAccountAsset = accountAsset.updateWhenBuyStock(this, isFirstBuy);
-    return new StockTransactionResultDto(updatedHolding, updatedAccountAsset);
-  }
+	public StockTransactionResultDto handleBuy(AccountAsset accountAsset,
+			HoldingIndividualStock holdingIndividualStock) {
+		validateBuy(accountAsset.getDeposit());
+		boolean isFirstBuy = holdingIndividualStock == null;
+		HoldingIndividualStock updatedHolding = isFirstBuy
+				? new HoldingIndividualStock(this, accountAsset.getId())
+				: holdingIndividualStock.updateWhenBuyStock(this);
+		AccountAsset updatedAccountAsset = accountAsset.updateWhenBuyStock(this, isFirstBuy);
+		return new StockTransactionResultDto(updatedHolding, updatedAccountAsset);
+	}
 
-  public StockTransactionResultDto handleSell(AccountAsset accountAsset,
-      HoldingIndividualStock holdingIndividualStock) {
-    validateSell(holdingIndividualStock);
-    boolean isLastStockSold = holdingIndividualStock.getQuantity().equals(this.getOrderQuantity());
-    HoldingIndividualStock updatedHolding = holdingIndividualStock.updateWhenSellStock(this);
-    AccountAsset updatedAccountAsset = accountAsset.updateWhenSellStock(this, isLastStockSold);
-    return new StockTransactionResultDto(updatedHolding, updatedAccountAsset);
-  }
+	public StockTransactionResultDto handleSell(AccountAsset accountAsset,
+			HoldingIndividualStock holdingIndividualStock) {
+		validateSell(holdingIndividualStock);
+		boolean isLastStockSold = holdingIndividualStock.getQuantity().equals(this.getOrderQuantity());
+		HoldingIndividualStock updatedHolding = holdingIndividualStock.updateWhenSellStock(this);
+		AccountAsset updatedAccountAsset = accountAsset.updateWhenSellStock(this, isLastStockSold);
+		return new StockTransactionResultDto(updatedHolding, updatedAccountAsset);
+	}
 
-  public void validateBuy(Long deposit) {
-    Long buyableQuantity = deposit / this.stockPrice;
-    if (buyableQuantity < this.getOrderQuantity()) {
-      throw new CustomException(CustomExceptionDetail.WRONG_BUY_ORDER);
-    }
-  }
+	private void validateBuy(Long deposit) {
+		Long buyableQuantity = deposit / this.stockPrice;
+		if (buyableQuantity < this.getOrderQuantity()) {
+			throw new CustomException(CustomExceptionDetail.WRONG_BUY_ORDER);
+		}
+	}
 
-  public void validateSell(HoldingIndividualStock holdingIndividualStock) {
-    Long sellableQuantity =
-        holdingIndividualStock != null ? holdingIndividualStock.getQuantity() : 0L;
-    if (sellableQuantity < this.getOrderQuantity()) {
-      throw new CustomException(CustomExceptionDetail.WRONG_SELL_QUANTITY);
-    }
-  }
+	private void validateSell(HoldingIndividualStock holdingIndividualStock) {
+		Long sellableQuantity =
+				holdingIndividualStock != null ? holdingIndividualStock.getQuantity() : 0L;
+		if (sellableQuantity < this.getOrderQuantity()) {
+			throw new CustomException(CustomExceptionDetail.WRONG_SELL_QUANTITY);
+		}
+	}
 }

--- a/src/main/java/com/Toou/Toou/domain/model/StockSellable.java
+++ b/src/main/java/com/Toou/Toou/domain/model/StockSellable.java
@@ -12,4 +12,10 @@ public class StockSellable {
 	private String stockCode;              // 종목 코드
 	private String stockName;              // 종목명
 	private Long sellableQuantity;
+
+	public static StockSellable of(HoldingIndividualStock holdingStock,
+			String stockCode, String stockName) {
+		Long quantity = (holdingStock != null) ? holdingStock.getQuantity() : 0L;
+		return new StockSellable(stockCode, stockName, quantity);
+	}
 }

--- a/src/main/java/com/Toou/Toou/usecase/BuyableStockService.java
+++ b/src/main/java/com/Toou/Toou/usecase/BuyableStockService.java
@@ -24,12 +24,13 @@ public class BuyableStockService implements BuyableStockUseCase {
 		StockMetadata stockMetadata = stockMetadataPort.findStockByStockCode(input.stockCode);
 		StockDailyHistory stockDailyHistory = stockHistoryPort.findStockHistoryByDate(
 				stockMetadata.getId(), input.buyDate);
-		Long closingPrice = stockDailyHistory.getClosingPrice();
-		Long deposit = accountAsset.getDeposit();
-		Long buyableQuantity = deposit / closingPrice;
-		StockBuyable stockBuyable = new StockBuyable(input.stockCode, stockMetadata.getStockName(),
-				closingPrice, deposit,
-				buyableQuantity);
+
+		StockBuyable stockBuyable = StockBuyable.of(
+				input.stockCode,
+				stockMetadata.getStockName(),
+				stockDailyHistory.getClosingPrice(),
+				accountAsset.getDeposit()
+		);
 		return new Output(stockBuyable);
 	}
 }

--- a/src/main/java/com/Toou/Toou/usecase/SellableStockService.java
+++ b/src/main/java/com/Toou/Toou/usecase/SellableStockService.java
@@ -24,10 +24,8 @@ public class SellableStockService implements SellableStockUseCase {
 		HoldingIndividualStock holdingIndividualStock = holdingStockPort.findHoldingByStockCodeAndAssetId(
 				input.stockCode, accountAsset.getId());
 		StockMetadata stockMetadata = stockMetadataPort.findStockByStockCode(input.stockCode);
-		Long sellableQuantity =
-				holdingIndividualStock != null ? holdingIndividualStock.getQuantity() : 0L;
-		StockSellable stockSellable = new StockSellable(
-				input.stockCode, stockMetadata.getStockName(), sellableQuantity);
+		StockSellable stockSellable = StockSellable.of(holdingIndividualStock,
+				stockMetadata.getStockCode(), stockMetadata.getStockName());
 		return new Output(stockSellable);
 	}
 }

--- a/src/test/java/com/Toou/Toou/domain/StockBuyableDomainTest.java
+++ b/src/test/java/com/Toou/Toou/domain/StockBuyableDomainTest.java
@@ -1,0 +1,57 @@
+package com.Toou.Toou.domain;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.Toou.Toou.domain.model.StockBuyable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("StockBuyable 도메인 테스트")
+public class StockBuyableDomainTest {
+
+	@Nested
+	@DisplayName("삼성전자 주식 구매 가능 개수 테스트")
+	class BuyableStockTests {
+
+		private StockBuyable stockBuyable;
+		private final String stockCode = "005930";
+		private final String stockName = "삼성전자";
+		private final Long closingPrice = 75000L;  // 삼성전자 종가 (75,000원)
+		private final Long deposit = 1_500_000L;  // 사용자 예치금 (150만 원)
+		private final Long expectedBuyableQuantity = deposit / closingPrice; // 20주 구매 가능
+
+		@BeforeEach
+		void setUp() {
+			stockBuyable = StockBuyable.of(stockCode, stockName, closingPrice, deposit);
+		}
+
+		@Test
+		@DisplayName("도메인 객체가 정상적으로 생성되는지 확인")
+		void testStockBuyableCreation() {
+			assertThat(stockBuyable).isNotNull();
+			assertThat(stockBuyable.getStockCode()).isEqualTo(stockCode);
+			assertThat(stockBuyable.getStockName()).isEqualTo(stockName);
+			assertThat(stockBuyable.getStockPrice()).isEqualTo(closingPrice);
+			assertThat(stockBuyable.getDeposit()).isEqualTo(deposit);
+			assertThat(stockBuyable.getBuyableQuantity()).isEqualTo(expectedBuyableQuantity);
+		}
+
+		@Test
+		@DisplayName("예치금이 충분할 때 구매 가능 개수 계산 확인")
+		void testBuyableQuantityCalculation() {
+			assertThat(stockBuyable.getBuyableQuantity()).isEqualTo(20L);
+		}
+
+		@Test
+		@DisplayName("예치금이 부족할 경우 구매 가능 개수가 0인지 확인")
+		void testZeroBuyableQuantity() {
+			Long insufficientDeposit = 50_000L;
+			StockBuyable insufficientStockBuyable = StockBuyable.of(stockCode, stockName, closingPrice,
+					insufficientDeposit);
+
+			assertThat(insufficientStockBuyable.getBuyableQuantity()).isEqualTo(0L);
+		}
+	}
+}

--- a/src/test/java/com/Toou/Toou/domain/StockOrderDomainTest.java
+++ b/src/test/java/com/Toou/Toou/domain/StockOrderDomainTest.java
@@ -16,81 +16,81 @@ import org.junit.jupiter.api.Test;
 @DisplayName("StockOrder 도메인 테스트")
 public class StockOrderDomainTest {
 
-  @Nested
-  @DisplayName("주식 매수 성공 테스트케이스 (보유 종목 0개)")
-  class BuyStockTests {
+	@Nested
+	@DisplayName("주식 매수 성공 테스트케이스 (보유 종목 0개)")
+	class BuyStockTests {
 
-    private StockOrder stockOrder;
-    private AccountAsset accountAsset;
-    private final Long stockPrice = 1000L;
-    private final Long orderQuantity = 1L;
+		private StockOrder stockOrder;
+		private AccountAsset accountAsset;
+		private final Long stockPrice = 1000L;
+		private final Long orderQuantity = 1L;
 
-    @BeforeEach
-    void setUp() {
-      final Long totalAsset = 1000000L;
-      final Long deposit = 1000000L;
-      final Long totalHoldingsValue = 0L;
-      final Long totalHoldingsQuantity = 0L;
-      final Double investmentYield = 0.0;
-      final Long totalPrincipal = 0L;
+		@BeforeEach
+		void setUp() {
+			final Long totalAsset = 1000000L;
+			final Long deposit = 1000000L;
+			final Long totalHoldingsValue = 0L;
+			final Long totalHoldingsQuantity = 0L;
+			final Double investmentYield = 0.0;
+			final Long totalPrincipal = 0L;
 
-      accountAsset = new AccountAsset(
-          1L, OAuthProvider.KAKAO, "id1",
-          totalAsset, deposit, totalHoldingsValue,
-          totalHoldingsQuantity, investmentYield, totalPrincipal
-      );
+			accountAsset = new AccountAsset(
+					1L, OAuthProvider.KAKAO, "id1",
+					totalAsset, deposit, totalHoldingsValue,
+					totalHoldingsQuantity, investmentYield, totalPrincipal
+			);
 
-      stockOrder = new StockOrder(
-          "s1", "sname1",
-          stockPrice, orderQuantity, TradeType.BUY, accountAsset
-      );
-    }
+			stockOrder = new StockOrder(
+					"s1", "sname1",
+					stockPrice, orderQuantity, TradeType.BUY, accountAsset
+			);
+		}
 
-    @Test
-    @DisplayName("DTO 결과 null 아님")
-    void testBuyStockResultDtoNotNull() {
-      // when
-      StockTransactionResultDto resultDto = stockOrder.handleBuy(accountAsset, null);
+		@Test
+		@DisplayName("도메인의 DTO 결과에 모두 null 없음")
+		void testBuyStockResultDtoNotNull() {
+			// when
+			StockTransactionResultDto resultDto = stockOrder.handleBuy(accountAsset, null);
 
-      // then
-      assertThat(resultDto).isNotNull();
-      assertThat(resultDto.updatedAccountAsset()).isNotNull();
-      assertThat(resultDto.updatedHolding()).isNotNull();
-    }
+			// then
+			assertThat(resultDto).isNotNull();
+			assertThat(resultDto.updatedAccountAsset()).isNotNull();
+			assertThat(resultDto.updatedHolding()).isNotNull();
+		}
 
-    @Test
-    @DisplayName("AccountAsset 결과")
-    void testBuyStockAccountAssetUpdate() {
-      // when
-      StockTransactionResultDto resultDto = stockOrder.handleBuy(accountAsset, null);
-      AccountAsset updatedAccountAsset = resultDto.updatedAccountAsset();
+		@Test
+		@DisplayName("AccountAsset 결과")
+		void testBuyStockAccountAssetUpdate() {
+			// when
+			StockTransactionResultDto resultDto = stockOrder.handleBuy(accountAsset, null);
+			AccountAsset updatedAccountAsset = resultDto.updatedAccountAsset();
 
-      // then
-      assertThat(updatedAccountAsset.getDeposit()).isEqualTo(
-          accountAsset.getDeposit() - (stockPrice * orderQuantity));
-      assertThat(updatedAccountAsset.getTotalHoldingsValue()).isEqualTo(
-          stockPrice * orderQuantity);
-      assertThat(updatedAccountAsset.getTotalHoldingsQuantity()).isEqualTo(orderQuantity);
-      assertThat(updatedAccountAsset.getTotalAsset()).isEqualTo(
-          updatedAccountAsset.getDeposit() + updatedAccountAsset.getTotalHoldingsValue());
-    }
+			// then
+			assertThat(updatedAccountAsset.getDeposit()).isEqualTo(
+					accountAsset.getDeposit() - (stockPrice * orderQuantity));
+			assertThat(updatedAccountAsset.getTotalHoldingsValue()).isEqualTo(
+					stockPrice * orderQuantity);
+			assertThat(updatedAccountAsset.getTotalHoldingsQuantity()).isEqualTo(orderQuantity);
+			assertThat(updatedAccountAsset.getTotalAsset()).isEqualTo(
+					updatedAccountAsset.getDeposit() + updatedAccountAsset.getTotalHoldingsValue());
+		}
 
-    @Test
-    @DisplayName("HoldingIndividualStock 결과")
-    void testBuyStockHoldingIndividualStockUpdate() {
-      // when
-      StockTransactionResultDto resultDto = stockOrder.handleBuy(accountAsset, null);
-      HoldingIndividualStock updatedHolding = resultDto.updatedHolding();
+		@Test
+		@DisplayName("HoldingIndividualStock 결과")
+		void testBuyStockHoldingIndividualStockUpdate() {
+			// when
+			StockTransactionResultDto resultDto = stockOrder.handleBuy(accountAsset, null);
+			HoldingIndividualStock updatedHolding = resultDto.updatedHolding();
 
-      // then
-      assertThat(updatedHolding).isNotNull();
-      assertThat(updatedHolding.getStockCode()).isEqualTo(stockOrder.getStockCode());
-      assertThat(updatedHolding.getStockName()).isEqualTo(stockOrder.getStockName());
-      assertThat(updatedHolding.getQuantity()).isEqualTo(orderQuantity);
-      assertThat(updatedHolding.getAverageBuyPrice()).isEqualTo(stockPrice);
-      assertThat(updatedHolding.getValuation()).isEqualTo(stockPrice * orderQuantity);
-      assertThat(updatedHolding.getYield()).isEqualTo(0.0); // 신규 매수이므로 수익률은 0
-    }
-  }
+			// then
+			assertThat(updatedHolding).isNotNull();
+			assertThat(updatedHolding.getStockCode()).isEqualTo(stockOrder.getStockCode());
+			assertThat(updatedHolding.getStockName()).isEqualTo(stockOrder.getStockName());
+			assertThat(updatedHolding.getQuantity()).isEqualTo(orderQuantity);
+			assertThat(updatedHolding.getAverageBuyPrice()).isEqualTo(stockPrice);
+			assertThat(updatedHolding.getValuation()).isEqualTo(stockPrice * orderQuantity);
+			assertThat(updatedHolding.getYield()).isEqualTo(0.0); // 신규 매수이므로 수익률은 0
+		}
+	}
 
 }

--- a/src/test/java/com/Toou/Toou/domain/StockSellableDomainTest.java
+++ b/src/test/java/com/Toou/Toou/domain/StockSellableDomainTest.java
@@ -1,0 +1,56 @@
+package com.Toou.Toou.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.Toou.Toou.domain.model.HoldingIndividualStock;
+import com.Toou.Toou.domain.model.MarketType;
+import com.Toou.Toou.domain.model.StockMetadata;
+import com.Toou.Toou.domain.model.StockSellable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("StockSellable 도메인 테스트")
+public class StockSellableDomainTest {
+
+	@Nested
+	@DisplayName("삼성전자 주식 판매 가능 개수 테스트")
+	class ValidStockSellableTests {
+
+		@Test
+		@DisplayName("삼성전자 주식을 보유한 경우 sellableQuantity가 정상적으로 설정되어야 한다.")
+		void shouldCreateStockSellableWithHoldingStock() {
+			// Given
+			HoldingIndividualStock holdingStock = new HoldingIndividualStock(
+					1L, "005930", "삼성전자", 70000L, 75000L, 100L, 7_500_000L, 7.1, 1L, 7_000_000L
+			);
+			StockMetadata stockMetadata = new StockMetadata(1L, "005930", "삼성전자", MarketType.KOSPI);
+
+			// When
+			StockSellable stockSellable = StockSellable.of(holdingStock, stockMetadata.getStockCode(),
+					stockMetadata.getStockName());
+
+			// Then
+			assertThat(stockSellable.getStockCode()).isEqualTo("005930");
+			assertThat(stockSellable.getStockName()).isEqualTo("삼성전자");
+			assertThat(stockSellable.getSellableQuantity()).isEqualTo(100L);
+		}
+
+		@Test
+		@DisplayName("삼성전자 주식을 보유하지 않은 경우 sellableQuantity가 0이 되어야 한다.")
+		void shouldCreateStockSellableWithZeroQuantityIfNoHoldingStock() {
+			// Given
+			HoldingIndividualStock holdingStock = null;  // 주식 없음
+			StockMetadata stockMetadata = new StockMetadata(1L, "005930", "삼성전자", MarketType.KOSPI);
+
+			// When
+			StockSellable stockSellable = StockSellable.of(holdingStock, stockMetadata.getStockCode(),
+					stockMetadata.getStockName());
+
+			// Then
+			assertThat(stockSellable.getStockCode()).isEqualTo("005930");
+			assertThat(stockSellable.getStockName()).isEqualTo("삼성전자");
+			assertThat(stockSellable.getSellableQuantity()).isEqualTo(0L);
+		}
+	}
+}


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type[#issue number]: 작업 내용 -->
<!-- ex) feat[#133]: canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

resolved: #54  <!-- #이슈번호. 머지되면 이슈가 종료됨-->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
- 서비스 계층에는 데이터를 가져오고, 저장하는 코드만 존재. 모든 비즈니스 로직은 도메인에 위치.

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
**buyable, sellable 테스트 작성, 리팩토링.** 
- 정적 팩토리 메서드 변수명 규칙에 따라, 매개변수가 여러 개라서 of로 명명.

**추가적으로 리팩토링**
- stock order 내부에서만 사용하는 함수를 private으로 변경.
- open api 어댑터는 영속성 컨텍스트를 사용하지 않아서, `@repository` -> `@component`로 변경.

## 고민한 점들(필수 X)
### 영속성 컨텍스트를 사용하지 않는 리포지토리는 `@repository`가 필요하지 않다
처음 open api 어댑터를 작성할때는 다른 어댑터처럼 관례적으로 `@repository` 어노테이션을 사용해서 빈을 등록했다. 하지만 해당 어댑터는 JPA를 사용하지 않고, 당연히 영속성 컨텍스트도 사용하지 않는다. 

공식문서에 따르면, "`@Repository`는 DAO(Data Access Object)를 나타내는 특화된 `@Component`"로서 데이터베이스 관련 예외를 스프링의 DataAccessException로 변환해준다. 하지만 데이터베이스를 접근하지 않고, 외부 api를 호출해서 데이터만 조회하는 경우에는 필요가 없다.

## 스크린샷(필수 X)
`test/.../domain` 실행해서 도메인 테스트 결과.
<img width="599" alt="image" src="https://github.com/user-attachments/assets/2be0f0fc-5d7a-4872-97a5-d897c0d9c0cf" />
