### PR TITLE
fix[#56]: 중복 데이터 방지, 서비스 save 루프 제거 

### DIFF
--- a/src/main/java/com/Toou/Toou/adapter/mysql/StockHistoryAdapter.java
+++ b/src/main/java/com/Toou/Toou/adapter/mysql/StockHistoryAdapter.java
@@ -40,6 +40,21 @@ public class StockHistoryAdapter implements StockHistoryPort {
 		return toDomainModel(savedEntity);
 	}
 
+	//	@Override
+//	public void saveAll(List<StockDailyHistory> stockDailyHistories) {
+//		List<StockHistoryEntity> entities = stockDailyHistories.stream()
+//				.map(this::toEntity)
+//				.collect(Collectors.toList());
+//		stockHistoryJpaRepository.saveAll(entities);
+//	}
+
+	@Override
+	public void saveAll(List<StockDailyHistory> stockDailyHistories) {
+		stockDailyHistories.forEach(stockDailyHistory -> {
+			StockHistoryEntity entity = toEntity(stockDailyHistory);
+			stockHistoryJpaRepository.insertIgnore(entity);
+		});
+	}
 
 	private StockDailyHistory toDomainModel(StockHistoryEntity entity) {
 		return new StockDailyHistory(

--- a/src/main/java/com/Toou/Toou/adapter/mysql/StockHistoryJpaRepository.java
+++ b/src/main/java/com/Toou/Toou/adapter/mysql/StockHistoryJpaRepository.java
@@ -4,6 +4,10 @@ import com.Toou.Toou.adapter.mysql.entity.StockHistoryEntity;
 import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface StockHistoryJpaRepository extends JpaRepository<StockHistoryEntity, Long> {
 
@@ -15,4 +19,31 @@ public interface StockHistoryJpaRepository extends JpaRepository<StockHistoryEnt
 	StockHistoryEntity findFirstByStockMetadataIdAndDateLessThanEqualOrderByDateDesc(
 			Long stockMetadataId,
 			LocalDate date);
+
+
+	@Modifying
+	@Transactional
+	@Query(
+			value =
+					"INSERT IGNORE INTO stock_history (stock_metadata_id, date, open_price, high_price, low_price, closing_price) "
+							+
+							"VALUES (:stockMetadataId, :date, :openPrice, :highPrice, :lowPrice, :closingPrice) ",
+			nativeQuery = true)
+	void insertIgnore(@Param("stockMetadataId") Long stockMetadataId,
+			@Param("date") LocalDate date,
+			@Param("openPrice") Long openPrice,
+			@Param("highPrice") Long highPrice,
+			@Param("lowPrice") Long lowPrice,
+			@Param("closingPrice") Long closingPrice);
+
+	default void insertIgnore(StockHistoryEntity entity) {
+		insertIgnore(
+				entity.getStockMetadataId(),
+				entity.getDate(),
+				entity.getOpenPrice(),
+				entity.getHighPrice(),
+				entity.getLowPrice(),
+				entity.getClosingPrice()
+		);
+	}
 }

--- a/src/main/java/com/Toou/Toou/port/out/StockHistoryPort.java
+++ b/src/main/java/com/Toou/Toou/port/out/StockHistoryPort.java
@@ -1,7 +1,6 @@
 package com.Toou.Toou.port.out;
 
 import com.Toou.Toou.domain.model.StockDailyHistory;
-
 import java.time.LocalDate;
 import java.util.List;
 
@@ -13,4 +12,6 @@ public interface StockHistoryPort {
 	StockDailyHistory findStockHistoryByDate(Long stockMetadataId, LocalDate date);
 
 	StockDailyHistory save(StockDailyHistory stockDailyHistory);
+
+	void saveAll(List<StockDailyHistory> stockDailyHistories);
 }

--- a/src/main/java/com/Toou/Toou/usecase/ListStockHistoryService.java
+++ b/src/main/java/com/Toou/Toou/usecase/ListStockHistoryService.java
@@ -38,9 +38,10 @@ public class ListStockHistoryService implements ListStockHistoryUseCase {
 			List<StockDailyHistory> externalHistories = stockOpenApiPort.findAllHistoriesBetweenDates(
 					stockMetadata.getId(),
 					stockMetadata.getStockName(), lastDate.plusDays(1), input.dateTo);
-			// 4. 가져온 데이터가 비어 있지 않으면 리스트에 추가하고 데이터베이스에도 저장
+
+			// 가져온 데이터가 비어 있지 않으면 리스트에 추가하고 데이터베이스에도 저장
 			if (!externalHistories.isEmpty()) {
-				externalHistories.forEach(stockHistoryPort::save);
+				stockHistoryPort.saveAll(externalHistories);
 				dailyHistories.addAll(externalHistories);
 
 				// 중복된 데이터가 있을 수 있으므로 정렬 및 중복 제거
@@ -53,10 +54,4 @@ public class ListStockHistoryService implements ListStockHistoryUseCase {
 		return new Output(dailyHistories, stockMetadata.getStockCode(), stockMetadata.getStockName(),
 				stockMetadata.getMarket());
 	}
-//
-//	private boolean hasAllHistoriesBetweenDates(List<StockDailyHistory> histories, LocalDate dateFrom,
-//			LocalDate dateTo) {
-//		// TODO: histories에 있는 각 history들의 date를 확인해서 dateFrom~dateTo 사이 모든 날짜를 커버하는지 확인하는 로직 필요
-//		return false;
-//	}
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -3,9 +3,11 @@ server:
 
 spring:
   datasource:
-    url: ${local-db.url}
-    username: ${local-db.username}
-    password: ${local-db.password}
+    url:
+      jdbc:h2:mem:testdb;MODE=MySQL
+    username: sa
+    password:
+
 
   h2:
     console:


### PR DESCRIPTION

<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type[#issue number]: 작업 내용 -->
<!-- ex) feat[#133]: canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

resolved: #56 <!-- #이슈번호. 머지되면 이슈가 종료됨-->

## 작업 개요
- 동일 종목, 동일 일자 가격 추가 방지
- 서비스 레이어에서 save 함수 반복 호출 제거

<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
여기에 작성하세요

## 작업 사항
- 서버 DB에 유니크 제약조건 설정 (stockMetadataId + date)
- INSERT IGNORE 로, 유니크 키 제약조건에 위배될경우 insert 무시.
- 리포지토리에서 엔티티 받아서 처리하도록 default 메서드 추가
- 로컬 환경변수를 명시적으로 바꿈. 추가로 H2도 mysql 모드로 변경.


## 고민한 점들(필수 X)
### 동일 종목의 새로운 데이터를 데이터베이스에 저장하는 요청이 두개 이상일 경우
같은 종목의 2023-03-10 이후의 데이터를 가져오는 요청과, 2023-04-10 ~ 2023-07-10 기간의 데이터를 가져오는 요청이 거의 동시에 들어올 경우 중복 데이터가 삽입됨을 확인했다. 

혹시 서버에도 그런 상황이 발생했는지 접속해서 알아봤고, 소량 발생했음을 확인했다. 
<img width="659" alt="image" src="https://github.com/user-attachments/assets/a29866e3-19aa-4a8e-870e-ec5a1a2083a9" />

저장된 중복 데이터를 삭제하고, (종목 + 날짜)로 유니크 제약조건을 걸어서 방지했다.

이럴 경우 insert 할 때 제약조건에 위배되면 db로부터 에러 응답을 받아서, 리포지토리도 수정했다. 

### 저장할때 시간 줄이기
### 1차 개선 → jpa repository의 saveall() 사용

기존 응답 시간은 약 11초(`11182ms`) 소요 -> `5821ms` 로 절반 정도 개선됨.

리포지토리에서 save 루프를 돌면 프록시 로직이 없어서 더 빨라졌다. 

```json
{
  "timestamp": "2025-03-15T17:06:02.166Z",
  "thread-id": 50,
  "logger": "com.Toou.Toou.filter.ReqResLoggingFilter",
  "level": "INFO",
  "message": "🌐 [HTTP REQUEST] IP: 0:0:0:0:0:0:0:1, Method: GET, URI: /api/stocks/001045/history, Query Params: dateFrom=2023-03-10, Body: Empty | 📩 [HTTP RESPONSE] Status: 200, Time: 11182ms, Body: {\"ok\":true,\"id\":null,\"stockCode\":\"001045\",\"stockName\":\"CJ우\",\"market\":\"KOSPI\",\"stockNewestPrice\":61900,\"newestDate\":\"2025-03-15\",\"dailyHistories\":[{\"date\":\"2023-03-13\",\"prices\":[50700,51100,50100,50700]},{\"date\":\"2023-03-14\",\"prices\":[49950,50800,49950,50200]},{\"date\":\"2023-03-15\",\"prices\":[50300,51200,50300,51100]},{\"date\":\"2023-03-16\",\"prices\":[51100,51100,50300,50700]},{\"date\":\"2023-03-17\",\"prices\":[50700,51200,50700,50900]},{\"date\":\"2023-03-20\",\"prices\":[50800,51500,50800,51500]},{\"date\":\"202..."
}
```

```java
// ListStockHistoryService

if (!externalHistories.isEmpty()) {
//				externalHistories.forEach(stockHistoryPort::save); <- 예전 코드
	stockHistoryPort.saveAll(externalHistories); // <- 추가
	dailyHistories.addAll(externalHistories);
```

```java
public void saveAll(List<StockDailyHistory> stockDailyHistories) {
	List<StockHistoryEntity> entities = stockDailyHistories.stream()
			.map(this::toEntity)
			.collect(Collectors.toList());
	stockHistoryJpaRepository.saveAll(entities);
}
```

```java
{"timestamp":"2025-03-15T17:43:39.430Z","thread-id":50,"logger":"p6spy","level":"INFO","message":"1742028219430 | conn=6 - 0 ms | statement | insert into stock_history (closing_price,date,high_price,low_price,open_price,stock_metadata_id,id) values (51100,'2023-03-15T00:00:00.000+0900',51200,50300,50300,14,default)"}
{"timestamp":"2025-03-15T17:43:39.430Z","thread-id":50,"logger":"p6spy","level":"INFO","message":"1742028219430 | conn=6 - 0 ms | statement | insert into stock_history (closing_price,date,high_price,low_price,open_price,stock_metadata_id,id) values (50200,'2023-03-14T00:00:00.000+0900',50800,49950,49950,14,default)"}
{"timestamp":"2025-03-15T17:43:39.431Z","thread-id":50,"logger":"p6spy","level":"INFO","message":"1742028219431 | conn=6 - 0 ms | statement | insert into stock_history (closing_price,date,high_price,low_price,open_price,stock_metadata_id,id) values (50700,'2023-03-13T00:00:00.000+0900',51100,50100,50700,14,default)"}
{"timestamp":"2025-03-15T17:43:39.437Z","thread-id":50,"logger":"p6spy","level":"INFO","message":"1742028219437 | conn=6 - 1 ms | commit | "}
{"timestamp":"2025-03-15T17:43:39.472Z","thread-id":50,"logger":"com.Toou.Toou.filter.ReqResLoggingFilter","level":"INFO","message":"🌐 [HTTP REQUEST] IP: 0:0:0:0:0:0:0:1, Method: GET, URI: /api/stocks/001045/history, Query Params: dateFrom=2023-03-10, Body: Empty | 📩 [HTTP RESPONSE] Status: 200, Time: 5821ms, Body: {\"ok\":true,\"id\":null,\"stockCode\":\"001045\",\"stockName\":\"CJ우\",\"market\":\"KOSPI\",\"stockNewestPrice\":61900,\"newestDate\":\"2025-03-15\",\"dailyHistories\":[{\"date\":\"2023-03-13\",\"prices\":[50700,51100,50100,50700]},{\"date\":\"2023-03-14\",\"prices\":[49950,50800,49950,50200]},{\"date\":\"2023-03-15\",\"prices\":[50300,51200,50300,51100]},{\"date\":\"2023-03-16\",\"prices\":[51100,51100,50300,50700]},{\"date\":\"2023-03-17\",\"prices\":[50700,51200,50700,50900]},{\"date\":\"2023-03-20\",\"prices\":[50800,51500,50800,51500]},{\"date\":\"202..."}
```

## 스크린샷(필수 X)

